### PR TITLE
Document the necessary security policy

### DIFF
--- a/SecurityPolicy.md
+++ b/SecurityPolicy.md
@@ -45,7 +45,7 @@ Permission necessary for AWS Watchman to do all the things.
 				"sns:Subscribe"
 			],
 			"Resource": [
-				"*"
+				"arn:aws:sns:<region>:<account-id>:*"
 			]
 		}
 	]
@@ -71,10 +71,10 @@ Permission necessary for AWS Watchman to do all the things.
 		{
 			"Effect": "Allow",
 			"Action": [
-				"cloudformation:UpdateStack"                
+				"cloudformation:UpdateStack"
 			],
 			"Resource": [
-				"*"
+				"arn:aws:cloudformation:<region>:<account-id>:stack/Watchman*"
 			]
 		},
 		{
@@ -83,7 +83,7 @@ Permission necessary for AWS Watchman to do all the things.
 				"s3:PutObject"
 			],
 			"Resource": [
-				"*"
+				"arn:aws:s3:::<watchman bucket>/*"
 			]
 		}
 	]


### PR DESCRIPTION
I think that we should store this info in the repo in some form so that it doesn't get lost.
If it turns out that Watchman needs other permissions then it can be PR'd to add them. 
If there's a way to document how one should lock down the resources tighter than "*" then that can be added as well.