### PR TITLE
Less sensitive ELB latency alarm

### DIFF
--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -263,11 +263,11 @@ namespace Watchman.Engine.Alarms
                 Name = "LatencyHigh",
                 Metric = "Latency",
                 Period = TimeSpan.FromMinutes(5),
-                EvaluationPeriods = 2,
+                EvaluationPeriods = 1,
                 Threshold = new Threshold
                 {
                     ThresholdType = ThresholdType.Absolute,
-                    Value = 0.25
+                    Value = 0.50
                 },
                 DimensionNames = new[] {"LoadBalancerName"},
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,


### PR DESCRIPTION
The problem is that this alarm went off at 7:25 am on almost no data (probably just 1 slow request)
The actual data points are 
`07:15, 0.001s`
`07:17, 0.493s` 
`07:39, 0.003s`

So lots of "no data" in between that. 

With the result that the average of 0.493s was over the alerting threshold, and this carried forward for the periods after that with no data. See also https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-alarm-single-data-point/

We're trying to make it less likely to go off as a false alarm, and still provide a timely alert when things go wrong. How do we make an alarm which is suitable for fast alerting when traffic is high, but not going off falsely when traffic is low?

Still todo: use a percentile metric. This might also help?