### PR TITLE
Change lambda aggregations

### DIFF
--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -132,7 +132,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] {"FunctionName"},
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Maximum,
+                Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Lambda
             },
             new AlarmDefinition
@@ -149,7 +149,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] {"FunctionName"},
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Maximum,
+                Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Lambda
             },
             new AlarmDefinition
@@ -165,7 +165,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] {"FunctionName"},
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Maximum,
+                Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Lambda
             }
        };


### PR DESCRIPTION
Change Errors and Throttles to `Sum` (was `Maximum`). This makes the alarms more when used over longer periods. We may need to make these configurable eventually though.

Change execution time to average as we discussed (until percentile support is available)