### PR TITLE
Added support for Kinesis streams

### DIFF
--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -62,6 +62,7 @@ The following services are supported
 - `Rds`
 - `AutoScaling`
 - `Lambda`
+- `Kinesis`
 - `Elb`
 - `VpcSubnet` (this is a custom service using JUST EAT custom metrics)
 
@@ -86,6 +87,11 @@ For each resource each of the default alarms will be applied. See [alarm definit
 - `ErrorsHigh`: 3 (count)
 - `DurationHigh`: 50 (% of defined Timeout)
 - `ThrottlesHigh`: 5 (count)
+
+### Kinesis
+
+- `ReadProvisionedThroughputExceededHigh`: 1 (count)
+- `WriteProvisionedThroughputExceededHigh`: 1 (count)
 
 ### VpcSubnets
 

--- a/Watchman.AwsResources.IntegrationTests/Service/Kinesis/KinesisStreamSourceTests.cs
+++ b/Watchman.AwsResources.IntegrationTests/Service/Kinesis/KinesisStreamSourceTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.CloudWatch;
+using NUnit.Framework;
+using TestHelper;
+using Watchman.AwsResources.Services.Kinesis;
+
+namespace Watchman.AwsResources.IntegrationTests.Service.Kinesis
+{
+    [TestFixture]
+    public class KinesisStreamSourceTests
+    {
+        [Test]
+        public async Task ReadAllStreamsShouldReturnResults()
+        {
+            var source = InitializeStreamSource();
+
+            var resources = await source.GetResourceNamesAsync();
+
+            Assert.That(resources, Is.Not.Null);
+            Assert.That(resources, Is.Not.Empty);
+        }
+
+        private static KinesisStreamSource InitializeStreamSource()
+        {
+            var cloudWatchClient = new AmazonCloudWatchClient(CredentialsReader.GetCredentials(), RegionEndpoint.EUWest1);
+
+            return new KinesisStreamSource(cloudWatchClient);
+        }
+    }
+}

--- a/Watchman.AwsResources.IntegrationTests/Watchman.AwsResources.IntegrationTests.csproj
+++ b/Watchman.AwsResources.IntegrationTests/Watchman.AwsResources.IntegrationTests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Service\AutoScaling\AutoScalingSourceTests.cs" />
     <Compile Include="Service\DynamoDb\TableDescriptionSourceTests.cs" />
     <Compile Include="Service\Elb\ElbSourceTests.cs" />
+    <Compile Include="Service\Kinesis\KinesisStreamSourceTests.cs" />
     <Compile Include="Service\Rds\RdsSourceTests.cs" />
     <Compile Include="Service\Lambda\LambdaSourceTests.cs" />
     <Compile Include="Service\Sqs\QueueSourceTests.cs" />

--- a/Watchman.AwsResources.Tests/Services/Kinesis/KinesisStreamAlarmDataProviderTests.cs
+++ b/Watchman.AwsResources.Tests/Services/Kinesis/KinesisStreamAlarmDataProviderTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Watchman.AwsResources.Services.Kinesis;
+
+namespace Watchman.AwsResources.Tests.Services.Kinesis
+{
+    [TestFixture]
+    public class KinesisStreamAlarmDataProviderTests
+    {
+        private KinesisStreamData _streamData;
+        private KinesisStreamAlarmDataProvider _streamDataProvider;
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            _streamData = new KinesisStreamData
+            {
+                Name = "Stream Name"
+            };
+
+            _streamDataProvider = new KinesisStreamAlarmDataProvider();
+        }
+
+        [Test]
+        public void GetDimensions_KnownDimensions_ReturnsValue()
+        {
+            //arange
+
+            //act
+            var result = _streamDataProvider.GetDimensions(_streamData, new List<string> { "StreamName" });
+
+            //assert
+            Assert.That(result.Count, Is.EqualTo(1));
+
+            var dim = result.Single();
+            Assert.That(dim.Value, Is.EqualTo(_streamData.Name));
+            Assert.That(dim.Name, Is.EqualTo("StreamName"));
+        }
+
+        [Test]
+        [ExpectedException(UserMessage = "Unsupported dimension UnknownDimension")]
+        public void GetDimensions_UnknownDimension_ThrowException()
+        {
+            //arange
+
+            //act
+            var result = _streamDataProvider.GetDimensions(_streamData, new List<string> { "UnknownDimension" });
+
+            //assert
+        }
+
+        [Test]
+        [ExpectedException(UserMessage = "Unsupported Lambda property name")]
+        public void GetAttribute_UnknownAttribute_ThrowException()
+        {
+            //arange
+
+            //act
+            var result = _streamDataProvider.GetValue(_streamData, "Unknown Attribute");
+
+            //assert
+        }
+    }
+}

--- a/Watchman.AwsResources.Tests/Services/Kinesis/KinesisStreamSourceTests.cs
+++ b/Watchman.AwsResources.Tests/Services/Kinesis/KinesisStreamSourceTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.CloudWatch;
+using Amazon.CloudWatch.Model;
+using Moq;
+using NUnit.Framework;
+using Watchman.AwsResources.Services.Kinesis;
+
+namespace Watchman.AwsResources.Tests.Services.Kinesis
+{
+    [TestFixture]
+    public class KinesisStreamSourceTests
+    {
+        private ListMetricsResponse _firstPage;
+        private ListMetricsResponse _secondPage;
+        private ListMetricsResponse _thirdPage;
+
+        private KinesisStreamSource _streamSource;
+
+        [SetUp]
+        public void Setup()
+        {
+            _firstPage = new ListMetricsResponse
+            {
+                NextToken = "token-1",
+                Metrics = new List<Metric>
+                {
+                    new Metric
+                    {
+                        MetricName = "GetRecords.IteratorAgeMilliseconds",
+                        Dimensions = new List<Dimension>
+                        {
+                            new Dimension
+                            {
+                                Name = "StreamName",
+                                Value = "Stream-1"
+                            }
+                        }
+                    }
+                }
+            };
+            _secondPage = new ListMetricsResponse
+            {
+                NextToken = "token-2",
+                Metrics = new List<Metric>
+                {
+                    new Metric
+                    {
+                        MetricName = "GetRecords.IteratorAgeMilliseconds",
+                        Dimensions = new List<Dimension>
+                        {
+                            new Dimension
+                            {
+                                Name = "StreamName",
+                                Value = "Stream-2"
+                            }
+                        }
+                    }
+                }
+            };
+            _thirdPage = new ListMetricsResponse
+            {
+                Metrics = new List<Metric>
+                {
+                    new Metric
+                    {
+                        MetricName = "GetRecords.IteratorAgeMilliseconds",
+                        Dimensions = new List<Dimension>
+                        {
+                            new Dimension
+                            {
+                                Name = "StreamName",
+                                Value = "Stream-3"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var cloudWatchMock = new Mock<IAmazonCloudWatch>();
+            cloudWatchMock.Setup(s => s.ListMetricsAsync(
+                It.Is<ListMetricsRequest>(r => r.MetricName == "GetRecords.IteratorAgeMilliseconds" && r.NextToken == null),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_firstPage);
+
+            cloudWatchMock.Setup(s => s.ListMetricsAsync(
+                It.Is<ListMetricsRequest>(r => r.MetricName == "GetRecords.IteratorAgeMilliseconds" && r.NextToken == "token-1"),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_secondPage);
+
+            cloudWatchMock.Setup(s => s.ListMetricsAsync(
+                It.Is<ListMetricsRequest>(r => r.MetricName == "GetRecords.IteratorAgeMilliseconds" && r.NextToken == "token-2"),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_thirdPage);
+
+            _streamSource = new KinesisStreamSource(cloudWatchMock.Object);
+        }
+
+        [Test]
+        public async Task GetResourcesAsync_MultiplePages_AllFetchedAndReturned()
+        {
+            // arrange
+
+            // act
+            var result = await _streamSource.GetResourceNamesAsync();
+
+            // assert
+            Assert.That(result.Count, Is.EqualTo(3));
+
+            Assert.That(result.First(), Is.EqualTo(_firstPage.Metrics.Single().Dimensions.Single().Value));
+            Assert.That(result.Skip(1).First(), Is.EqualTo(_secondPage.Metrics.Single().Dimensions.Single().Value));
+            Assert.That(result.Skip(2).First(), Is.EqualTo(_thirdPage.Metrics.Single().Dimensions.Single().Value));
+        }
+
+        [Test]
+        public async Task GetResourcesAsync_SinglePage_FetchedAndReturned()
+        {
+            // arrange
+            _firstPage.NextToken = null;
+
+            // act
+            var result = await _streamSource.GetResourceNamesAsync();
+
+            // assert
+            Assert.That(result.Count, Is.EqualTo(1));
+
+            Assert.That(result.First(), Is.EqualTo(_firstPage.Metrics.Single().Dimensions.Single().Value));
+        }
+
+        [Test]
+        public async Task GetResourcesAsync_EmptyResult_EmptyListReturned()
+        {
+            // arrange
+            _firstPage.NextToken = null;
+            _firstPage.Metrics = new List<Metric>();
+
+            // act
+            var result = await _streamSource.GetResourceNamesAsync();
+
+            // assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetResouceAsync_ReturnsCorrectResource()
+        {
+            // arrange
+            var secondStreamName = _secondPage.Metrics.First().Dimensions.Single().Value;
+
+            // act
+            var result = await _streamSource.GetResourceAsync(secondStreamName);
+
+            // assert
+            Assert.That(result.Name, Is.EqualTo(secondStreamName));
+            Assert.That(result.Resource, Is.InstanceOf<KinesisStreamData>());
+            Assert.That(result.Resource.Name, Is.EqualTo(secondStreamName));
+        }
+    }
+}

--- a/Watchman.AwsResources.Tests/Watchman.AwsResources.Tests.csproj
+++ b/Watchman.AwsResources.Tests/Watchman.AwsResources.Tests.csproj
@@ -78,6 +78,8 @@
     <Compile Include="Services\DynamoDb\TableDescriptionSourceTests.cs" />
     <Compile Include="Services\Elb\ElbAlarmDataProviderTests.cs" />
     <Compile Include="Services\Elb\ElbSourceTests.cs" />
+    <Compile Include="Services\Kinesis\KinesisStreamAlarmDataProviderTests.cs" />
+    <Compile Include="Services\Kinesis\KinesisStreamSourceTests.cs" />
     <Compile Include="Services\Sqs\SqsSourceTests.cs" />
     <Compile Include="Services\Lambda\LambdaAlarmDataProviderTests.cs" />
     <Compile Include="Services\Lambda\LambdaSourceTests.cs" />

--- a/Watchman.AwsResources/Services/DynamoDb/TableDescriptionSource.cs
+++ b/Watchman.AwsResources/Services/DynamoDb/TableDescriptionSource.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;

--- a/Watchman.AwsResources/Services/Kinesis/KinesisStreamAlarmDataProvider.cs
+++ b/Watchman.AwsResources/Services/Kinesis/KinesisStreamAlarmDataProvider.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.CloudWatch.Model;
+
+namespace Watchman.AwsResources.Services.Kinesis
+{
+    public class KinesisStreamAlarmDataProvider : IAlarmDimensionProvider<KinesisStreamData>, IResourceAttributesProvider<KinesisStreamData>
+    {
+        public List<Dimension> GetDimensions(KinesisStreamData resource, IList<string> dimensionNames) =>
+            dimensionNames.Select(x => GetDimension(resource, x))
+                .ToList();
+
+        private Dimension GetDimension(KinesisStreamData resource, string dimensionName)
+        {
+            switch (dimensionName)
+            {
+                case "StreamName":
+                    return new Dimension { Name = "StreamName", Value = resource.Name };
+
+                default:
+                    throw new Exception("Unsupported dimension " + dimensionName);
+            }
+        }
+
+        public decimal GetValue(KinesisStreamData resource, string property)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Watchman.AwsResources/Services/Kinesis/KinesisStreamData.cs
+++ b/Watchman.AwsResources/Services/Kinesis/KinesisStreamData.cs
@@ -1,0 +1,7 @@
+namespace Watchman.AwsResources.Services.Kinesis
+{
+    public class KinesisStreamData
+    {
+        public string Name { get; set; }
+    }
+}

--- a/Watchman.AwsResources/Services/Kinesis/KinesisStreamSource.cs
+++ b/Watchman.AwsResources/Services/Kinesis/KinesisStreamSource.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudWatch;
+using Amazon.CloudWatch.Model;
+
+namespace Watchman.AwsResources.Services.Kinesis
+{
+    public class KinesisStreamSource : ResourceSourceBase<KinesisStreamData>
+    {
+        private readonly IAmazonCloudWatch _amazonCloudWatch;
+
+        public KinesisStreamSource(IAmazonCloudWatch amazonCloudWatch)
+        {
+            _amazonCloudWatch = amazonCloudWatch;
+        }
+
+        protected override string GetResourceName(KinesisStreamData resource) => resource.Name;
+
+        protected override async Task<IEnumerable<KinesisStreamData>> FetchResources()
+        {
+            var names = await ReadStreamNames();
+
+            return names.Select(n => new KinesisStreamData() { Name = n }).ToList();
+        }
+
+        private async Task<IList<string>> ReadStreamNames()
+        {
+            var metrics = await ReadStreamMetrics();
+
+            return metrics
+                .SelectMany(ExtractStreamNames)
+                .OrderBy(qn => qn)
+                .Distinct()
+                .ToList();
+        }
+
+        private async Task<List<Metric>> ReadStreamMetrics()
+        {
+            var metrics = new List<Metric>();
+            string token = null;
+            do
+            {
+                var request = new ListMetricsRequest
+                {
+                    MetricName = "GetRecords.IteratorAgeMilliseconds",
+                    NextToken = token
+                };
+                var response = await _amazonCloudWatch.ListMetricsAsync(request);
+
+                if (response != null)
+                {
+                    token = response.NextToken;
+                    metrics.AddRange(response.Metrics);
+                }
+                else
+                {
+                    token = null;
+                }
+            }
+            while (token != null);
+
+            return metrics;
+        }
+
+        private static IEnumerable<string> ExtractStreamNames(Metric metric) =>
+            metric.Dimensions
+                .Where(d => d.Name == "StreamName")
+                .Select(d => d.Value);
+    }
+}

--- a/Watchman.AwsResources/Watchman.AwsResources.csproj
+++ b/Watchman.AwsResources/Watchman.AwsResources.csproj
@@ -72,6 +72,9 @@
     <Compile Include="Services\AutoScaling\AutoScalingGroupAlarmDataProvider.cs" />
     <Compile Include="Services\AutoScaling\AutoScalingGroupSource.cs" />
     <Compile Include="Services\DynamoDb\TableDescriptionSource.cs" />
+    <Compile Include="Services\Kinesis\KinesisStreamAlarmDataProvider.cs" />
+    <Compile Include="Services\Kinesis\KinesisStreamSource.cs" />
+    <Compile Include="Services\Kinesis\KinesisStreamData.cs" />
     <Compile Include="Services\Lambda\LambdaAlarmDataProvider.cs" />
     <Compile Include="Services\Lambda\LambdaSource.cs" />
     <Compile Include="Services\Rds\RdsAlarmDataProvider.cs" />

--- a/Watchman.Configuration/AlertingGroup.cs
+++ b/Watchman.Configuration/AlertingGroup.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
 using Watchman.Configuration.Generic;
 
 namespace Watchman.Configuration

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Amazon.CloudWatch;
 using Watchman.Configuration;
@@ -167,8 +167,24 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Lambda
+            },
+            new AlarmDefinition
+            {
+                Name = "IteratorAgeHigh",
+                Metric = "IteratorAge",
+                Period = TimeSpan.FromMinutes(5),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = 300000
+                },
+                DimensionNames = new[] {"FunctionName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Maximum,
+                Namespace = AwsNamespace.Lambda
             }
-       };
+        };
 
         public static IList<AlarmDefinition> VpcSubnets = new List<AlarmDefinition>
         {
@@ -190,7 +206,7 @@ namespace Watchman.Engine.Alarms
                 Namespace = "JUSTEAT/PlatformLimits",
                 AlertOnInsufficientData = true
             }
-       };
+        };
 
         public static IList<AlarmDefinition> Elb = new List<AlarmDefinition>
         {
@@ -275,7 +291,7 @@ namespace Watchman.Engine.Alarms
                 Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Elb
             },
-             new AlarmDefinition
+            new AlarmDefinition
             {
                 Name = "UnHealthyHostCountHigh",
                 Metric = "UnHealthyHostCount",
@@ -291,6 +307,42 @@ namespace Watchman.Engine.Alarms
                 Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Elb
             }
-       };
+        };
+
+        public static IList<AlarmDefinition> KinesisStream = new List<AlarmDefinition>
+        {
+            new AlarmDefinition
+            {
+                Name = "ReadProvisionedThroughputExceededHigh",
+                Metric = "ReadProvisionedThroughputExceeded",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = 1
+                },
+                DimensionNames = new[] {"StreamName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.Kinesis
+            },
+            new AlarmDefinition
+            {
+                Name = "WriteProvisionedThroughputExceededHigh",
+                Metric = "WriteProvisionedThroughputExceeded",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = 1
+                },
+                DimensionNames = new[] {"StreamName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.Kinesis
+            }
+        };
     }
 }

--- a/Watchman.Engine/AwsNamespace.cs
+++ b/Watchman.Engine/AwsNamespace.cs
@@ -1,4 +1,4 @@
-﻿namespace Watchman.Engine
+namespace Watchman.Engine
 {
     public static class AwsNamespace
     {
@@ -9,5 +9,6 @@
         public const string AutoScaling = "AWS/AutoScaling";
         public const string Lambda = "AWS/Lambda";
         public const string Elb = "AWS/ELB";
+        public const string Kinesis = "AWS/Kinesis";
     }
 }

--- a/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
+++ b/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
@@ -49,6 +49,12 @@ namespace Watchman.Engine.Generation
             return Map(input, id, a => GetService(a, id), Defaults.Elb);
         }
 
+        public static WatchmanServiceConfiguration MapStream(WatchmanConfiguration input)
+        {
+            const string id = "KinesisStream";
+            return Map(input, id, a => GetService(a, id), Defaults.KinesisStream);
+        }
+
         private static WatchmanServiceConfiguration Map(WatchmanConfiguration input,
             string serviceName,
             Func<AlertingGroup, AwsServiceAlarms> readServiceFromGroup,

--- a/Watchman/AwsBootstrapper.cs
+++ b/Watchman/AwsBootstrapper.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.AutoScaling;
+using Amazon.AutoScaling;
 using Amazon.CloudFormation;
 using Amazon.CloudWatch;
 using Amazon.DynamoDBv2;

--- a/Watchman/AwsServiceBootstrapper.cs
+++ b/Watchman/AwsServiceBootstrapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Amazon.AutoScaling.Model;
 using Amazon.ElasticLoadBalancing.Model;
 using Amazon.Lambda.Model;
@@ -7,6 +7,7 @@ using StructureMap;
 using Watchman.AwsResources;
 using Watchman.AwsResources.Services.AutoScaling;
 using Watchman.AwsResources.Services.Elb;
+using Watchman.AwsResources.Services.Kinesis;
 using Watchman.AwsResources.Services.Lambda;
 using Watchman.AwsResources.Services.Rds;
 using Watchman.AwsResources.Services.VpcSubnet;
@@ -42,6 +43,10 @@ namespace Watchman
             AddService<LoadBalancerDescription, ElbSource, ElbAlarmDataProvider, ElbAlarmDataProvider>(
                 registry, WatchmanServiceConfigurationMapper.MapElb
                 );
+
+            AddService<KinesisStreamData, KinesisStreamSource, KinesisStreamAlarmDataProvider, KinesisStreamAlarmDataProvider>(
+                registry, WatchmanServiceConfigurationMapper.MapStream
+            );
         }
 
         private static void AddService<TServiceModel, TSource, TDimensionProvider, TAttributeProvider>(

--- a/Watchman/IocBootstrapper.cs
+++ b/Watchman/IocBootstrapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using Amazon.DynamoDBv2.Model;
 using StructureMap;
@@ -13,7 +13,6 @@ using Watchman.Engine.Generation.Sqs;
 using Watchman.Engine.Logging;
 using Watchman.Engine.Sns;
 using Amazon.CloudFormation;
-using Amazon.Runtime.SharedInterfaces;
 using Amazon.S3;
 using Watchman.Engine.Generation.Generic;
 


### PR DESCRIPTION
Few notes:

- I decided to fetch the list of streams from cloudwatch as the listStreams api call has limits around transactions per second (5 per second per account). Getting the stream names from cloudwatch has no such issues.
- Added alarms around read and write provisioned throughput for a stream. Useful for when you need to scale a stream (increase number of shards).
- Added a lambda alarm for iterator age. This is only useful for lambdas that have a stream trigger but is good for detecting excessive backlogs or errors.