### PR TITLE
Ignore resources that do not exist when specified by name

### DIFF
--- a/Watchman.Engine.Tests/Generation/ResourceNamePopulatorTests.cs
+++ b/Watchman.Engine.Tests/Generation/ResourceNamePopulatorTests.cs
@@ -216,5 +216,37 @@ namespace Watchman.Engine.Tests.Generation
             // assert
             Assert.That(group.Service.Resources.Count, Is.EqualTo(1));
         }
+
+        [Test]
+        public async Task PopulateResourceNames_NonExistantResourceSpecified_Ingnored()
+        {
+            // arrange
+            var resourceSourceStub = new Mock<IResourceSource<ExampleServiceModel>>();
+            resourceSourceStub
+                .Setup(x => x.GetResourceNamesAsync())
+                .ReturnsAsync(new List<string>
+                {
+                    "ItemY"
+                });
+
+            var sut = new ResourceNamePopulator<ExampleServiceModel>(new ConsoleAlarmLogger(false), resourceSourceStub.Object);
+
+            var group = new ServiceAlertingGroup
+            {
+                Service = new AwsServiceAlarms
+                {
+                    Resources = new List<ResourceThresholds>
+                    {
+                        new ResourceThresholds { Name = "DoesNotExist" }
+                    }
+                }
+            };
+
+            // act
+            await sut.PopulateResourceNames(group);
+
+            // assert
+            Assert.That(group.Service.Resources.Count, Is.EqualTo(0));
+        }
     }
 }


### PR DESCRIPTION
For the newer services (i.e. everything other than dynamo, SQS). Currently you get an error if the named resource doesn't exist, which has caused some confusion. I don't think this behaviour is necessarily expected and already doesn't exist for SQS.

The same approach is used for SQS (converting resource names to patterns for lookup rather than treating them as valid resource names) https://github.com/justeat/AwsWatchman/commit/612ff4a5c31ecf241d92c3989ee3ebd090724383#diff-c8d43a27f0bf4301d1a2d4a1ee415ba3L30
