### PR TITLE
When a cloudformation stack deploy fails

### DIFF
--- a/Watchman.Engine.Tests/Generation/CloudFormationAlarmCreatorTests.cs
+++ b/Watchman.Engine.Tests/Generation/CloudFormationAlarmCreatorTests.cs
@@ -120,15 +120,11 @@ namespace Watchman.Engine.Tests.Generation
             SetupListStacksToReturnStackNames(stackName);
             SetStatusForStackName(stackName, "UPDATE_COMPLETE");
 
-            var sut = new CloudFormationAlarmCreator(
-                new CloudformationStackDeployer(
-                    new ConsoleAlarmLogger(false), 
-                    _cloudFormationMock.Object, 
-                    _s3Mock.Object, 
-                    null,
-                    TimeSpan.FromMilliseconds(5), 
-                    TimeSpan.FromMilliseconds(5))
-                );
+            var deployer = MakeDeployer(null,
+                TimeSpan.FromMilliseconds(5),
+                TimeSpan.FromMilliseconds(5));
+
+            var sut = new CloudFormationAlarmCreator(deployer, new ConsoleAlarmLogger(false));
 
             sut.AddAlarm(alarm);
 
@@ -152,15 +148,11 @@ namespace Watchman.Engine.Tests.Generation
             SetupListStacksToReturnStackNames();
             SetStatusForStackName(stackName, "CREATE_COMPLETE");
 
-            var sut = new CloudFormationAlarmCreator(
-                new CloudformationStackDeployer(
-                    new ConsoleAlarmLogger(false), 
-                    _cloudFormationMock.Object, 
-                    _s3Mock.Object, 
-                    null,
-                    TimeSpan.FromMilliseconds(5), 
-                    TimeSpan.FromMilliseconds(5)
-                    ));
+            var deployer = MakeDeployer(null,
+                TimeSpan.FromMilliseconds(5),
+                TimeSpan.FromMilliseconds(5));
+
+            var sut = new CloudFormationAlarmCreator(deployer, new ConsoleAlarmLogger(false));
 
             sut.AddAlarm(alarm);
 
@@ -178,13 +170,8 @@ namespace Watchman.Engine.Tests.Generation
         public async Task SaveChanges_NoAlarms_NoStackChangesMade()
         {
             // arrange
-            var sut = new CloudFormationAlarmCreator(
-                new CloudformationStackDeployer(
-                    new ConsoleAlarmLogger(false), 
-                    _cloudFormationMock.Object,
-                    _s3Mock.Object, 
-                    null
-                    ));
+            var deployer = MakeDeployer();
+            var sut = new CloudFormationAlarmCreator(deployer, new ConsoleAlarmLogger(false));
 
             // act
             await sut.SaveChanges(false);
@@ -209,12 +196,8 @@ namespace Watchman.Engine.Tests.Generation
 
             SetupListStacksToReturnStackNames();
 
-            var sut = new CloudFormationAlarmCreator(
-                new CloudformationStackDeployer(
-                    new ConsoleAlarmLogger(false), 
-                    _cloudFormationMock.Object, 
-                    _s3Mock.Object, 
-                    null));
+            var deployer = MakeDeployer();
+            var sut = new CloudFormationAlarmCreator(deployer, new ConsoleAlarmLogger(false));
 
             sut.AddAlarm(alarm);
 
@@ -240,14 +223,11 @@ namespace Watchman.Engine.Tests.Generation
             SetupStackStatusSequence(stackName, new List<string> { "CREATE_IN_PROGRESS", "CREATE_IN_PROGRESS", "CREATE_COMPLETE" });
 
             var statusCheckDelay = TimeSpan.FromMilliseconds(200);
-            var sut = new CloudFormationAlarmCreator(
-                new CloudformationStackDeployer(
-                    new ConsoleAlarmLogger(false), 
-                    _cloudFormationMock.Object, 
-                    _s3Mock.Object, 
-                    null,
-                    statusCheckDelay, 
-                    TimeSpan.FromMinutes(5)));
+
+            var deployer = MakeDeployer(null,
+                statusCheckDelay, TimeSpan.FromMinutes(5));
+            var sut = new CloudFormationAlarmCreator(deployer, new ConsoleAlarmLogger(false));
+
             sut.AddAlarm(alarm);
 
             var start = DateTime.UtcNow;
@@ -288,15 +268,9 @@ namespace Watchman.Engine.Tests.Generation
 
             var s3Location = new S3Location("bucket", "s3/path");
 
-            var sut = new CloudFormationAlarmCreator(
-                new CloudformationStackDeployer(
-                    new ConsoleAlarmLogger(false), 
-                    _cloudFormationMock.Object, 
-                    _s3Mock.Object, 
-                    s3Location,
-                    TimeSpan.Zero,
-                    TimeSpan.FromMinutes(1)
-                    ));
+            var deployer = MakeDeployer(s3Location, TimeSpan.Zero, TimeSpan.FromMinutes(1));
+
+            var sut = new CloudFormationAlarmCreator(deployer, new ConsoleAlarmLogger(false));
 
             foreach (var alarm in alarms)
             {
@@ -334,14 +308,9 @@ namespace Watchman.Engine.Tests.Generation
 
             var s3Location = new S3Location("bucket", "s3/path");
 
-            var sut = new CloudFormationAlarmCreator(
-                new CloudformationStackDeployer(
-                    new ConsoleAlarmLogger(false), 
-                    _cloudFormationMock.Object, 
-                    _s3Mock.Object, 
-                    s3Location,
-                    TimeSpan.Zero,
-                    TimeSpan.FromMinutes(1)));
+            var deployer = MakeDeployer(s3Location, TimeSpan.Zero, TimeSpan.FromMinutes(1));
+
+            var sut = new CloudFormationAlarmCreator(deployer, new ConsoleAlarmLogger(false));
 
             sut.AddAlarm(alarm);
 
@@ -360,6 +329,26 @@ namespace Watchman.Engine.Tests.Generation
                         && s.TemplateURL == null
                         && !string.IsNullOrWhiteSpace(s.TemplateBody)),
                    It.IsAny<CancellationToken>()), Times.Exactly(1));
+        }
+
+        private CloudformationStackDeployer MakeDeployer(
+            S3Location s3Location, TimeSpan wait, TimeSpan waitTimeout)
+        {
+            return new CloudformationStackDeployer(
+                new ConsoleAlarmLogger(false),
+                _cloudFormationMock.Object,
+                _s3Mock.Object,
+                s3Location,
+                wait, waitTimeout);
+        }
+
+        private CloudformationStackDeployer MakeDeployer()
+        {
+            return new CloudformationStackDeployer(
+                new ConsoleAlarmLogger(false),
+                _cloudFormationMock.Object,
+                _s3Mock.Object,
+                null);
         }
     }
 }

--- a/Watchman.Engine/Generation/Generic/CloudFormationAlarmCreator.cs
+++ b/Watchman.Engine/Generation/Generic/CloudFormationAlarmCreator.cs
@@ -56,14 +56,14 @@ namespace Watchman.Engine.Generation.Generic
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e, "Failed to deploy stack " + stackName);
+                    _logger.Error(e, $"Error deploying stack {stackName}");
                     failedStacks++;
                 }
             }
 
             if (failedStacks > 0)
             {
-                throw new WatchmanException(failedStacks + " stacks failed");
+                throw new WatchmanException(failedStacks + " stacks failed to deploy");
             }
         }
 

--- a/Watchman.Engine/Generation/Generic/CloudFormationAlarmCreator.cs
+++ b/Watchman.Engine/Generation/Generic/CloudFormationAlarmCreator.cs
@@ -48,11 +48,11 @@ namespace Watchman.Engine.Generation.Generic
 
             foreach (var group in groupedBySuffix)
             {
-                var stackName = "Watchman-" + group.Name;
                 var alarms = group.Alarms;
+                var stackName = "Watchman-" + group.Name;
                 try
                 {
-                    await GenerateAndDeployStack(dryRun, alarms, stackName);
+                    await GenerateAndDeployStack(alarms, stackName, dryRun);
                 }
                 catch (Exception e)
                 {
@@ -67,7 +67,8 @@ namespace Watchman.Engine.Generation.Generic
             }
         }
 
-        private async Task GenerateAndDeployStack(bool dryRun, IEnumerable<Alarm> alarms, string stackName)
+        private async Task GenerateAndDeployStack(IEnumerable<Alarm> alarms,
+            string stackName, bool dryRun)
         {
             var template = new CloudWatchCloudFormationTemplate();
             template.AddAlarms(alarms);


### PR DESCRIPTION
When a cloudformation stack deploy fails with an exception
as we have seen, the program stops dead - so bad stack "a" blocks run of stacks "b,c,d,e" etc
rather try all the remaining stacks
and then fail.

Fix for an issue that we have seen.