### PR TITLE
Non deploy mode for cloudformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The allowed commandline parameters are:
 * `AwsRegion` The AWS region to use. Optional, default is `eu-west-1`.
 * `ConfigFolder`: path to config files. Required.
 * `Verbose`: One of `true` or `false`. Give more detailed output. Optional, default is `false`.
+* `WriteCloudformationTemplatesToDirectory`. If set, alarms deployed via CloudFormation will be written to this folder instead of deployed. Note that this does not affect SQS and DynamoDb alarms which currently use a different deployment method.
 
 AWS connection credentials will be found in the following order:
 * If `AwsAccessKey` and `AwsSecretKey` are specified, these will be used.

--- a/Watchman.Engine/Generation/Generic/DummyCloudFormationStackDeployer.cs
+++ b/Watchman.Engine/Generation/Generic/DummyCloudFormationStackDeployer.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Threading.Tasks;
+using Watchman.Engine.Logging;
+
+namespace Watchman.Engine.Generation.Generic
+{
+    public class DummyCloudFormationStackDeployer : ICloudformationStackDeployer
+    {
+        private readonly string _basePath;
+        private readonly IAlarmLogger _logger;
+
+        public DummyCloudFormationStackDeployer(string basePath, IAlarmLogger logger)
+        {
+            _basePath = basePath;
+            _logger = logger;
+        }
+
+        public Task DeployStack(string name, string body, bool isDryRun)
+        {
+            var path = Path.Combine(_basePath, $"{name}.json");
+
+            if (!Directory.Exists(_basePath))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            _logger.Info($"Writing cloudformation file to {path}");
+
+            File.WriteAllText(path, body);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Watchman.Engine/Generation/Generic/ICloudformationStackDeployer.cs
+++ b/Watchman.Engine/Generation/Generic/ICloudformationStackDeployer.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Watchman.Engine.Generation.Generic
 {

--- a/Watchman/IocBootstrapper.cs
+++ b/Watchman/IocBootstrapper.cs
@@ -67,13 +67,13 @@ namespace Watchman
             registry.For<IOrphanQueuesReporter>().Use<OrphanQueuesReporter>();
             registry.For<ISqsAlarmGenerator>().Use<SqsAlarmGenerator>();
 
-            if (!string.IsNullOrWhiteSpace(parameters.WriteCloudformationTemplatesToDirectory))
+            if (!string.IsNullOrWhiteSpace(parameters.WriteCloudFormationTemplatesToDirectory))
             {
                 registry
                     .For<ICloudformationStackDeployer>()
                     .Use(
                         ctx => new DummyCloudFormationStackDeployer(
-                            parameters.WriteCloudformationTemplatesToDirectory,
+                            parameters.WriteCloudFormationTemplatesToDirectory,
                             ctx.GetInstance<IAlarmLogger>()));
             }
             else

--- a/Watchman/StartupParameters.cs
+++ b/Watchman/StartupParameters.cs
@@ -29,5 +29,8 @@ namespace Watchman
 
         [Option("TemplateS3Path", HelpText = "Base s3 path for cloudformation template deployment")]
         public string TemplateS3Path { get; set; }
+
+        [Option("WriteCloudformationTemplatesToDirectory", HelpText = "Output cloudformation templates to folder instead of deploying")]
+        public string WriteCloudformationTemplatesToDirectory { get; set; }
     }
 }

--- a/Watchman/StartupParameters.cs
+++ b/Watchman/StartupParameters.cs
@@ -30,7 +30,7 @@ namespace Watchman
         [Option("TemplateS3Path", HelpText = "Base s3 path for cloudformation template deployment")]
         public string TemplateS3Path { get; set; }
 
-        [Option("WriteCloudformationTemplatesToDirectory", HelpText = "Output cloudformation templates to folder instead of deploying")]
-        public string WriteCloudformationTemplatesToDirectory { get; set; }
+        [Option("WriteCloudFormationTemplatesToDirectory", HelpText = "Output cloudformation templates to folder instead of deploying")]
+        public string WriteCloudFormationTemplatesToDirectory { get; set; }
     }
 }


### PR DESCRIPTION
Adds `WriteCloudformationTemplatesToDirectory` option. 

If set, alarms deployed via CloudFormation will be written to this folder instead of deployed. This is useful when doing manual testing of changes and comparing templates.