### PR TITLE
Refactoring generic services

### DIFF
--- a/Watchman.Engine.Tests/Generation/CloudFormationAlarmCreatorTests.cs
+++ b/Watchman.Engine.Tests/Generation/CloudFormationAlarmCreatorTests.cs
@@ -96,7 +96,6 @@ namespace Watchman.Engine.Tests.Generation
                 {
                     new AlertEmail("test@test.com")
                 },
-                new List<ReportTarget>(),
                 false
             );
         }

--- a/Watchman.Engine.Tests/Generation/CloudFormationAlarmCreatorTests.cs
+++ b/Watchman.Engine.Tests/Generation/CloudFormationAlarmCreatorTests.cs
@@ -83,22 +83,22 @@ namespace Watchman.Engine.Tests.Generation
                     return Task.FromResult(result);
                 });
         }
-        private string ExpectedStackName(ServiceAlertingGroup group)
+        private string ExpectedStackName(AlertingGroupParameters group)
         {
             return $"Watchman-{group.Name.ToLowerInvariant()}";
         }
 
-        private ServiceAlertingGroup Group()
+        private AlertingGroupParameters Group()
         {
-            return new ServiceAlertingGroup
-            {
-                Name = "group-name",
-                AlarmNameSuffix = "group-suffix",
-                Targets = new List<AlertTarget>()
+            return new AlertingGroupParameters("group-name",
+                "group-suffix",
+                new List<AlertTarget>()
                 {
-                    new AlertEmail() { Email = "test@test.com" }
-                }
-            };
+                    new AlertEmail("test@test.com")
+                },
+                new List<ReportTarget>(),
+                false
+            );
         }
         private static Alarm Alarm(string name = "Test alarm")
         {

--- a/Watchman.Engine.Tests/Generation/Generic/CloudWatchCloudFormationTemplateTests.cs
+++ b/Watchman.Engine.Tests/Generation/Generic/CloudWatchCloudFormationTemplateTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -22,7 +22,7 @@ namespace Watchman.Engine.Tests.Generation.Generic
     {
         private const string AlertingGroupName = "AlertingGroupName";
 
-        private static Alarm CreateExampleAlarm(List<AlertTarget> targets, AwsResource<FakeResourceType> resource)
+        private static Alarm CreateExampleAlarm(AwsResource<FakeResourceType> resource)
         {
             return new Alarm()
             {
@@ -35,11 +35,6 @@ namespace Watchman.Engine.Tests.Generation.Generic
                     AlertOnOk = true
                 },
                 AlarmName = "",
-                AlertingGroup = new ServiceAlertingGroup()
-                {
-                    Name = AlertingGroupName,
-                    Targets = targets
-                },
                 Dimensions = new List<Dimension>(),
                 Resource = resource
             };
@@ -53,14 +48,16 @@ namespace Watchman.Engine.Tests.Generation.Generic
             var resource = new AwsResource<FakeResourceType>("name", new FakeResourceType());
 
             var alarms = new List<Alarm>();
-            alarms.Add(CreateExampleAlarm(new List<AlertTarget>()
+            alarms.Add(CreateExampleAlarm(resource));
+
+            var targets = new List<AlertTarget>()
             {
                 new AlertEmail("test@test.com"),
                 new AlertUrl("url@url.com")
-            }, resource));
+            };
 
             // act
-            var template = new CloudWatchCloudFormationTemplate();
+            var template = new CloudWatchCloudFormationTemplate("group-name", targets);
             template.AddAlarms(alarms);
             var result = template.WriteJson();
 
@@ -80,10 +77,10 @@ namespace Watchman.Engine.Tests.Generation.Generic
             var resource = new AwsResource<FakeResourceType>("name", new FakeResourceType());
 
             var alarms = new List<Alarm>();
-            alarms.Add(CreateExampleAlarm(new List<AlertTarget>(), resource));
+            alarms.Add(CreateExampleAlarm(resource));
 
             // act
-            var template = new CloudWatchCloudFormationTemplate();
+            var template = new CloudWatchCloudFormationTemplate("group-name", new List<AlertTarget>());
             template.AddAlarms(alarms);
             var result = template.WriteJson();
 
@@ -101,16 +98,16 @@ namespace Watchman.Engine.Tests.Generation.Generic
         {
             // arrange
             var resource = new AwsResource<FakeResourceType>("name", new FakeResourceType());
-
-            var alarms = new List<Alarm>();
-            alarms.Add(CreateExampleAlarm(new List<AlertTarget>()
+            var targets = new List<AlertTarget>()
             {
                 new AlertEmail("test1@test.com"),
                 new AlertEmail("test2@test.com")
-            }, resource));
+            };
+            var alarms = new List<Alarm>();
+            alarms.Add(CreateExampleAlarm(resource));
 
             // act
-            var template = new CloudWatchCloudFormationTemplate();
+            var template = new CloudWatchCloudFormationTemplate(AlertingGroupName, targets);
             template.AddAlarms(alarms);
             var result = template.WriteJson();
 
@@ -137,14 +134,15 @@ namespace Watchman.Engine.Tests.Generation.Generic
             var resource = new AwsResource<FakeResourceType>("name", new FakeResourceType());
 
             var alarms = new List<Alarm>();
-            alarms.Add(CreateExampleAlarm(new List<AlertTarget>()
+            var targets = new List<AlertTarget>()
             {
                 new AlertUrl("http://banana"),
                 new AlertUrl("https://banana2"),
-            }, resource));
+            };
+            alarms.Add(CreateExampleAlarm(resource));
 
             // act
-            var template = new CloudWatchCloudFormationTemplate();
+            var template = new CloudWatchCloudFormationTemplate(AlertingGroupName, targets);
             template.AddAlarms(alarms);
             var result = template.WriteJson();
 
@@ -177,14 +175,15 @@ namespace Watchman.Engine.Tests.Generation.Generic
             var resource = new AwsResource<FakeResourceType>("name", new FakeResourceType());
 
             var alarms = new List<Alarm>();
-            alarms.Add(CreateExampleAlarm(new List<AlertTarget>()
+            var targets = new List<AlertTarget>()
             {
                 new AlertUrl("http://banana"),
                 new AlertEmail("test@test.com"),
-            }, resource));
+            };
+            alarms.Add(CreateExampleAlarm(resource));
 
             // act
-            var template = new CloudWatchCloudFormationTemplate();
+            var template = new CloudWatchCloudFormationTemplate("group-name", targets);
             template.AddAlarms(alarms);
             var result = template.WriteJson();
 

--- a/Watchman.Engine.Tests/Generation/ResourceNamePopulatorTests.cs
+++ b/Watchman.Engine.Tests/Generation/ResourceNamePopulatorTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Moq;
@@ -54,6 +54,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var group = new ServiceAlertingGroup
             {
+                GroupParameters = new AlertingGroupParameters("name", "suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -120,6 +121,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var group = new ServiceAlertingGroup
             {
+                GroupParameters = new AlertingGroupParameters("name", "suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -163,6 +165,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var group = new ServiceAlertingGroup
             {
+                GroupParameters = new AlertingGroupParameters("name", "suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -199,6 +202,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var group = new ServiceAlertingGroup
             {
+                GroupParameters = new AlertingGroupParameters("name", "suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -233,6 +237,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var group = new ServiceAlertingGroup
             {
+                GroupParameters = new AlertingGroupParameters("name", "suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>

--- a/Watchman.Engine.Tests/Generation/ServiceAlarmBuilderTests.cs
+++ b/Watchman.Engine.Tests/Generation/ServiceAlarmBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Moq;
@@ -76,7 +76,7 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup, defaults);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
 
             // assert
 
@@ -124,7 +124,7 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup, defaults);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
 
             // assert
 
@@ -176,7 +176,7 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup, defaults);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
 
             // assert
 
@@ -219,7 +219,7 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup, defaults);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
 
             // assert
 
@@ -271,7 +271,7 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup, defaults);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
 
             // assert
 
@@ -349,7 +349,7 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup, defaults);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
 
             // assert
 
@@ -403,7 +403,7 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup, defaults);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
 
             // assert
 
@@ -461,7 +461,7 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup, defaults);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
 
             // assert
 

--- a/Watchman.Engine.Tests/Generation/ServiceAlarmBuilderTests.cs
+++ b/Watchman.Engine.Tests/Generation/ServiceAlarmBuilderTests.cs
@@ -54,8 +54,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var alertingGroup = new ServiceAlertingGroup
             {
-                AlarmNameSuffix = "Suffix",
-                Name = "TestAlarm",
+                GroupParameters = new AlertingGroupParameters("TestAlarm", "Suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -76,7 +75,8 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults,
+                alertingGroup.GroupParameters.AlarmNameSuffix);
 
             // assert
 
@@ -98,8 +98,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var alertingGroup = new ServiceAlertingGroup
             {
-                AlarmNameSuffix = "Suffix",
-                Name = "TestAlarm",
+                GroupParameters = new AlertingGroupParameters("TestAlarm", "Suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -124,7 +123,8 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults,
+                alertingGroup.GroupParameters.AlarmNameSuffix);
 
             // assert
 
@@ -146,8 +146,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var alertingGroup = new ServiceAlertingGroup
             {
-                AlarmNameSuffix = "Suffix",
-                Name = "TestAlarm",
+                GroupParameters = new AlertingGroupParameters("TestAlarm", "Suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -176,7 +175,8 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults,
+                alertingGroup.GroupParameters.AlarmNameSuffix);
 
             // assert
 
@@ -197,8 +197,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var alertingGroup = new ServiceAlertingGroup
             {
-                AlarmNameSuffix = "Suffix",
-                Name = "TestAlarm",
+                GroupParameters = new AlertingGroupParameters("TestAlarm", "Suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -219,7 +218,8 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults,
+                alertingGroup.GroupParameters.AlarmNameSuffix);
 
             // assert
 
@@ -241,8 +241,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var alertingGroup = new ServiceAlertingGroup
             {
-                AlarmNameSuffix = "Suffix",
-                Name = "TestAlarm",
+                GroupParameters = new AlertingGroupParameters("TestAlarm", "Suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -271,7 +270,8 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults,
+                alertingGroup.GroupParameters.AlarmNameSuffix);
 
             // assert
 
@@ -323,8 +323,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var alertingGroup = new ServiceAlertingGroup
             {
-                AlarmNameSuffix = "Suffix",
-                Name = "TestAlarm",
+                GroupParameters = new AlertingGroupParameters("TestAlarm", "Suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -349,7 +348,8 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults,
+                alertingGroup.GroupParameters.AlarmNameSuffix);
 
             // assert
 
@@ -381,8 +381,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var alertingGroup = new ServiceAlertingGroup
             {
-                AlarmNameSuffix = "Suffix",
-                Name = "TestAlarm",
+                GroupParameters = new AlertingGroupParameters("TestAlarm", "Suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -403,7 +402,8 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults,
+                alertingGroup.GroupParameters.AlarmNameSuffix);
 
             // assert
 
@@ -435,8 +435,7 @@ namespace Watchman.Engine.Tests.Generation
 
             var alertingGroup = new ServiceAlertingGroup
             {
-                AlarmNameSuffix = "Suffix",
-                Name = "TestAlarm",
+                GroupParameters = new AlertingGroupParameters("TestAlarm", "Suffix"),
                 Service = new AwsServiceAlarms
                 {
                     Resources = new List<ResourceThresholds>
@@ -461,7 +460,8 @@ namespace Watchman.Engine.Tests.Generation
 
             // act
 
-            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults, alertingGroup.AlarmNameSuffix);
+            var result = await _generator.GenerateAlarmsFor(alertingGroup.Service, defaults,
+                alertingGroup.GroupParameters.AlarmNameSuffix);
 
             // assert
 

--- a/Watchman.Engine/AlertingGroupParameters.cs
+++ b/Watchman.Engine/AlertingGroupParameters.cs
@@ -13,21 +13,17 @@ namespace Watchman.Engine
 
         public IReadOnlyCollection<AlertTarget> Targets { get; }
 
-        public IReadOnlyCollection<ReportTarget> ReportTargets { get; }
-
         public bool IsCatchAll { get; }
 
         public AlertingGroupParameters(
             string name,
             string alarmNameSuffix,
             List<AlertTarget> targets = null,
-            List<ReportTarget> reportTargets = null,
             bool isCatchAll = false)
         {
             Name = name;
             AlarmNameSuffix = alarmNameSuffix;
             Targets = (targets ?? new List<AlertTarget>()).AsReadOnly();
-            ReportTargets = (reportTargets ?? new List<ReportTarget>()).AsReadOnly();
             IsCatchAll = isCatchAll;
         }
         
@@ -43,11 +39,6 @@ namespace Watchman.Engine
                 foreach (var target in Targets)
                 {
                     hash = hash * 23 + target.GetHashCode();
-                }
-
-                foreach (var reportTarget in ReportTargets)
-                {
-                    hash = hash * 23 + reportTarget.GetHashCode();
                 }
 
                 hash = hash * 23 + IsCatchAll.GetHashCode();
@@ -69,7 +60,6 @@ namespace Watchman.Engine
             return compare.IsCatchAll == IsCatchAll
                 && compare.Name == Name
                 && compare.AlarmNameSuffix == AlarmNameSuffix
-                && compare.ReportTargets.SequenceEqual(ReportTargets)
                 && compare.Targets.SequenceEqual(Targets);
         }
     }

--- a/Watchman.Engine/AlertingGroupParameters.cs
+++ b/Watchman.Engine/AlertingGroupParameters.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Watchman.Configuration;
+
+namespace Watchman.Engine
+{
+    public class AlertingGroupParameters
+    {
+        public string Name { get; }
+
+        public string AlarmNameSuffix { get; }
+
+        public IReadOnlyCollection<AlertTarget> Targets { get; }
+
+        public IReadOnlyCollection<ReportTarget> ReportTargets { get; }
+
+        public bool IsCatchAll { get; }
+
+        public AlertingGroupParameters(
+            string name,
+            string alarmNameSuffix,
+            List<AlertTarget> targets = null,
+            List<ReportTarget> reportTargets = null,
+            bool isCatchAll = false)
+        {
+            Name = name;
+            AlarmNameSuffix = alarmNameSuffix;
+            Targets = (targets ?? new List<AlertTarget>()).AsReadOnly();
+            ReportTargets = (reportTargets ?? new List<ReportTarget>()).AsReadOnly();
+            IsCatchAll = isCatchAll;
+        }
+        
+        // from https://stackoverflow.com/a/263416/22224
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hash = 486187739;
+                hash = hash * 23 + Name.GetHashCode();
+                hash = hash * 23 + AlarmNameSuffix.GetHashCode();
+
+                foreach (var target in Targets)
+                {
+                    hash = hash * 23 + target.GetHashCode();
+                }
+
+                foreach (var reportTarget in ReportTargets)
+                {
+                    hash = hash * 23 + reportTarget.GetHashCode();
+                }
+
+                hash = hash * 23 + IsCatchAll.GetHashCode();
+                return hash;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            var compare = obj as AlertingGroupParameters;
+
+            if (compare == null) return false;
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return compare.IsCatchAll == IsCatchAll
+                && compare.Name == Name
+                && compare.AlarmNameSuffix == AlarmNameSuffix
+                && compare.ReportTargets.SequenceEqual(ReportTargets)
+                && compare.Targets.SequenceEqual(Targets);
+        }
+    }
+}

--- a/Watchman.Engine/Generation/Alarm.cs
+++ b/Watchman.Engine/Generation/Alarm.cs
@@ -7,7 +7,6 @@ namespace Watchman.Engine.Generation
     public class Alarm
     {
         public string AlarmName { get; set;  }
-        public ServiceAlertingGroup AlertingGroup { get; set; }
         public List<Dimension> Dimensions { get; set; }
         public AlarmDefinition AlarmDefinition { get; set; }
         public IAwsResource Resource { get; set; }

--- a/Watchman.Engine/Generation/Generic/IAlarmCreator.cs
+++ b/Watchman.Engine/Generation/Generic/IAlarmCreator.cs
@@ -1,10 +1,11 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Watchman.Engine.Generation.Generic
 {
     public interface IAlarmCreator
     {
-        void AddAlarm(Alarm alarm);
+        void AddAlarms(ServiceAlertingGroup group, IList<Alarm> alarms);
         Task SaveChanges(bool dryRun);
     }
 }

--- a/Watchman.Engine/Generation/Generic/IAlarmCreator.cs
+++ b/Watchman.Engine/Generation/Generic/IAlarmCreator.cs
@@ -5,7 +5,7 @@ namespace Watchman.Engine.Generation.Generic
 {
     public interface IAlarmCreator
     {
-        void AddAlarms(ServiceAlertingGroup group, IList<Alarm> alarms);
+        void AddAlarms(AlertingGroupParameters group, IList<Alarm> alarms);
         Task SaveChanges(bool dryRun);
     }
 }

--- a/Watchman.Engine/Generation/Generic/OrphanResourcesFinder.cs
+++ b/Watchman.Engine/Generation/Generic/OrphanResourcesFinder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Watchman.AwsResources;
@@ -18,7 +18,7 @@ namespace Watchman.Engine.Generation.Generic
             IEnumerable<ServiceAlertingGroup> alertingGroups)
         {
             var monitoredResources = alertingGroups
-                .Where(ag => !ag.IsCatchAll)
+                .Where(ag => !ag.GroupParameters.IsCatchAll)
                 .SelectMany(ag => ag.Service.Resources)
                 .Select(t => t.Name)
                 .Distinct();

--- a/Watchman.Engine/Generation/ResourceNamePopulator.cs
+++ b/Watchman.Engine/Generation/ResourceNamePopulator.cs
@@ -22,7 +22,7 @@ namespace Watchman.Engine.Generation
 
         public async Task PopulateResourceNames(ServiceAlertingGroup alertingGroup)
         {
-            alertingGroup.Service.Resources = await ExpandTablePatterns(alertingGroup.Service, alertingGroup.Name);
+            alertingGroup.Service.Resources = await ExpandTablePatterns(alertingGroup.Service, alertingGroup.GroupParameters.Name);
         }
 
         private static IEnumerable<ResourceThresholds> Distinct(IEnumerable<ResourceThresholds> input)

--- a/Watchman.Engine/Generation/ServiceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/ServiceAlarmGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Watchman.AwsResources;
@@ -26,11 +26,12 @@ namespace Watchman.Engine.Generation
         {
             foreach (var alertingGroup in config.AlertingGroups)
             {
-                var alarms = await _serviceAlarmBuilder.GenerateAlarmsFor(alertingGroup, config.Defaults);
-                foreach (var alarm in alarms)
-                {
-                    _creator.AddAlarm(alarm);
-                }
+                var alarmsForGroup = await _serviceAlarmBuilder.GenerateAlarmsFor(
+                    alertingGroup.Service,
+                    config.Defaults,
+                    alertingGroup.AlarmNameSuffix);
+
+                _creator.AddAlarms(alertingGroup, alarmsForGroup);
             }
         }
     }

--- a/Watchman.Engine/Generation/ServiceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/ServiceAlarmGenerator.cs
@@ -29,9 +29,9 @@ namespace Watchman.Engine.Generation
                 var alarmsForGroup = await _serviceAlarmBuilder.GenerateAlarmsFor(
                     alertingGroup.Service,
                     config.Defaults,
-                    alertingGroup.AlarmNameSuffix);
+                    alertingGroup.GroupParameters.AlarmNameSuffix);
 
-                _creator.AddAlarms(alertingGroup, alarmsForGroup);
+                _creator.AddAlarms(alertingGroup.GroupParameters, alarmsForGroup);
             }
         }
     }

--- a/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
+++ b/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Watchman.Configuration;
@@ -84,12 +84,14 @@ namespace Watchman.Engine.Generation
         {
             return new ServiceAlertingGroup
             {
-                AlarmNameSuffix = input.AlarmNameSuffix,
-                IsCatchAll = input.IsCatchAll,
-                Name = input.Name,
-                ReportTargets = input.ReportTargets,
-                Service = service,
-                Targets = input.Targets
+                GroupParameters = new AlertingGroupParameters(
+                    input.Name,
+                    input.AlarmNameSuffix,
+                    input.Targets,
+                    input.ReportTargets,
+                    input.IsCatchAll
+                ),
+                Service = service
             };
         }
 

--- a/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
+++ b/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
@@ -88,7 +88,6 @@ namespace Watchman.Engine.Generation
                     input.Name,
                     input.AlarmNameSuffix,
                     input.Targets,
-                    input.ReportTargets,
                     input.IsCatchAll
                 ),
                 Service = service

--- a/Watchman.Engine/ServiceAlertingGroup.cs
+++ b/Watchman.Engine/ServiceAlertingGroup.cs
@@ -1,20 +1,10 @@
-﻿using System.Collections.Generic;
-using Watchman.Configuration;
 using Watchman.Configuration.Generic;
 
 namespace Watchman.Engine
 {
     public class ServiceAlertingGroup
     {
-        public string Name { get; set; }
-
-        public string AlarmNameSuffix { get; set; }
-
-        public List<AlertTarget> Targets { get; set; }
-
-        public List<ReportTarget> ReportTargets { get; set; }
-
-        public bool IsCatchAll { get; set; }
+        public AlertingGroupParameters GroupParameters { get; set; }
 
         public AwsServiceAlarms Service { get; set; }
     }

--- a/Watchman.Engine/Sns/SnsCreator.cs
+++ b/Watchman.Engine/Sns/SnsCreator.cs
@@ -27,11 +27,11 @@ namespace Watchman.Engine.Sns
 
         public async Task<string> EnsureSnsTopic(ServiceAlertingGroup alertingGroup, bool dryRun)
         {
-            var snsTopicArn = await _snsTopicCreator.EnsureSnsTopic(alertingGroup.Name, dryRun);
+            var snsTopicArn = await _snsTopicCreator.EnsureSnsTopic(alertingGroup.GroupParameters.Name, dryRun);
 
             if (!dryRun)
             {
-                await _snsSubscriptionCreator.EnsureSnsSubscriptions(alertingGroup.Targets, snsTopicArn);
+                await _snsSubscriptionCreator.EnsureSnsSubscriptions(alertingGroup.GroupParameters.Targets, snsTopicArn);
             }
             return snsTopicArn;
         }

--- a/Watchman.Tests/ConfigHelper.cs
+++ b/Watchman.Tests/ConfigHelper.cs
@@ -15,6 +15,25 @@ namespace Watchman.Tests
             List<ResourceThresholds> resources
         )
         {
+            return CreateBasicConfiguration(name,
+                suffix,
+                new Dictionary<string, AwsServiceAlarms>()
+                {
+                    {
+                        serviceName, new AwsServiceAlarms()
+                        {
+                            Resources = resources
+                        }
+                    }
+                });
+        }
+
+        public static WatchmanConfiguration CreateBasicConfiguration(
+            string name,
+            string suffix,
+            Dictionary<string, AwsServiceAlarms> services
+        )
+        {
             return new WatchmanConfiguration()
             {
                 AlertingGroups = new List<AlertingGroup>()
@@ -27,15 +46,7 @@ namespace Watchman.Tests
                         {
                             new AlertEmail("test@example.com")
                         },
-                        Services = new Dictionary<string, AwsServiceAlarms>()
-                        {
-                            {
-                                serviceName, new AwsServiceAlarms()
-                                {
-                                    Resources = resources
-                                }
-                            }
-                        }
+                        Services = services
                     }
                 }
             };

--- a/Watchman.Tests/Fakes/FakeAwsClients.cs
+++ b/Watchman.Tests/Fakes/FakeAwsClients.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Lambda;
+using Amazon.Lambda.Model;
+using Moq;
+
+namespace Watchman.Tests.Fakes
+{
+    internal static class FakeAwsClients
+    {
+        public static IAmazonDynamoDB CreateDynamoClientForTables(IEnumerable<TableDescription> tables)
+        {
+            tables = tables.ToList();
+
+            var fakeDynamo = new Mock<IAmazonDynamoDB>();
+
+            fakeDynamo
+                .Setup(x => x.ListTablesAsync((string)null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ListTablesResponse()
+                {
+                    TableNames = tables.Select(t => t.TableName).ToList()
+                });
+
+            foreach (var table in tables)
+            {
+                fakeDynamo
+                    .Setup(x => x.DescribeTableAsync(table.TableName, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new DescribeTableResponse()
+                    {
+                        Table = table
+                    });
+
+            }
+
+            return fakeDynamo.Object;
+        }
+
+        public static IAmazonLambda CreateLambdaClientForFunctions(IEnumerable<FunctionConfiguration> functions)
+        {
+            var fakeLambda = new Mock<IAmazonLambda>();
+            fakeLambda
+                .Setup(l => l.ListFunctionsAsync(It.IsAny<ListFunctionsRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ListFunctionsResponse()
+                {
+                    Functions = functions.ToList()
+                });
+
+            return fakeLambda.Object;
+        }
+    }
+}

--- a/Watchman.Tests/Fakes/TemplateExtensions.cs
+++ b/Watchman.Tests/Fakes/TemplateExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
@@ -26,7 +26,9 @@ namespace Watchman.Tests.Fakes
 
         public static string Dimension(this Resource r, string dimension)
         {
-            return r.Dimensions().Single(d => d.Name == dimension).Value;
+            return r.Dimensions()
+                .SingleOrDefault(d => d.Name == dimension)
+                ?.Value;
         }
 
         public static Dictionary<string, List<Resource>> AlarmsByDimension(this Template t, string dimension)
@@ -34,9 +36,15 @@ namespace Watchman.Tests.Fakes
             return t
                 .Alarms()
                 .Values
+                .Select(z => new
+                {
+                    dimension = z.Dimension(dimension),
+                    resource = z
+                })
+                .Where(z => z.dimension != null)
                 .GroupBy(
-                    z => z.Dimension("TableName"),
-                    z => z,
+                    z => z.dimension,
+                    z => z.resource,
                     (table, alarms) => new { table, alarms })
                 .ToDictionary(z => z.table, z => z.alarms.ToList());
         }

--- a/Watchman.Tests/IoCHelper.cs
+++ b/Watchman.Tests/IoCHelper.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using Moq;
+using StructureMap.Diagnostics;
 using Watchman.AwsResources;
 using Watchman.Configuration;
 using Watchman.Configuration.Load;
@@ -21,32 +23,63 @@ namespace Watchman.Tests
             Func<WatchmanConfiguration, WatchmanServiceConfiguration> mapper,
             IAlarmCreator creator,
             IConfigLoader loader
-        ) where T:class
+        ) where T: class
         {
-            var fakeLogger = new Mock<IAlarmLogger>();
+            var builder = new Builder(loader, creator);
+            builder.AddService(source, dimensionProvider, attributeProvider, mapper);
+            return builder.Build();
+        }
+    }
 
-            var task = new ServiceAlarmTasks<T>(
-                fakeLogger.Object,
-                new ResourceNamePopulator<T>(fakeLogger.Object, source),
-                new ServiceAlarmGenerator<T>(
-                    creator, 
-                    new ServiceAlarmBuilder<T>(source, dimensionProvider, attributeProvider)),
-                new OrphanResourcesReporter<T>(
-                    new OrphanResourcesFinder<T>(source),
-                    new OrphansLogger(fakeLogger.Object)),
-                mapper
-            );
+    class Builder
+    {
+        private readonly IConfigLoader _loader;
+        private readonly IAlarmCreator _creator;
+
+        private readonly IAlarmLogger _logger = new Mock<IAlarmLogger>().Object;
+
+        private readonly List<IServiceAlarmTasks> _serviceAlarmTasks = new List<IServiceAlarmTasks>();
+
+        public Builder(IConfigLoader loader,
+            IAlarmCreator creator)
+        {
+            _loader = loader;
+            _creator = creator;
+        }
+
+        public AlarmLoaderAndGenerator Build()
+        {
 
             return new AlarmLoaderAndGenerator(
-                fakeLogger.Object,
-                loader,
+                _logger,
+                _loader,
                 new Mock<IDynamoAlarmGenerator>().Object,
                 new Mock<IOrphanTablesReporter>().Object,
                 new Mock<ISqsAlarmGenerator>().Object,
                 new Mock<IOrphanQueuesReporter>().Object,
-                creator,
-                new[] {task}
+                _creator,
+                _serviceAlarmTasks
             );
+        }
+
+        public void AddService<T>(IResourceSource<T> source,
+            IAlarmDimensionProvider<T> dimensionProvider,
+            IResourceAttributesProvider<T> attributeProvider,
+            Func<WatchmanConfiguration, WatchmanServiceConfiguration> mapper) where T : class
+        {
+            var task = new ServiceAlarmTasks<T>(
+                _logger,
+                new ResourceNamePopulator<T>(_logger, source),
+                new ServiceAlarmGenerator<T>(
+                    _creator,
+                    new ServiceAlarmBuilder<T>(source, dimensionProvider, attributeProvider)),
+                new OrphanResourcesReporter<T>(
+                    new OrphanResourcesFinder<T>(source),
+                    new OrphansLogger(_logger)),
+                mapper
+            );
+
+            _serviceAlarmTasks.Add(task);
         }
     }
 }

--- a/Watchman.Tests/MultipleServiceAlarmTests.cs
+++ b/Watchman.Tests/MultipleServiceAlarmTests.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.CloudWatch;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Lambda;
+using Amazon.Lambda.Model;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Watchman.AwsResources.Services.DynamoDb;
+using Watchman.AwsResources.Services.Lambda;
+using Watchman.Configuration.Generic;
+using Watchman.Engine;
+using Watchman.Engine.Generation;
+using Watchman.Engine.Generation.Generic;
+using Watchman.Engine.Logging;
+using Watchman.Tests.Fakes;
+
+namespace Watchman.Tests
+{
+    public class MultipleServiceAlarmTests
+    {
+        private IAmazonDynamoDB CreateDynamoClientForTables(IEnumerable<TableDescription> tables)
+        {
+            tables = tables.ToList();
+
+            var fakeDynamo = new Mock<IAmazonDynamoDB>();
+
+            fakeDynamo
+                .Setup(x => x.ListTablesAsync((string)null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ListTablesResponse()
+                {
+                    TableNames = tables.Select(t => t.TableName).ToList()
+                });
+
+            foreach (var table in tables)
+            {
+                fakeDynamo
+                    .Setup(x => x.DescribeTableAsync(table.TableName, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new DescribeTableResponse()
+                    {
+                        Table = table
+                    });
+
+            }
+
+            return fakeDynamo.Object;
+        }
+
+        private IAmazonLambda CreateLambdaClientForFunctions(IEnumerable<FunctionConfiguration> functions)
+        {
+            var fakeLambda = new Mock<IAmazonLambda>();
+            fakeLambda
+                .Setup(l => l.ListFunctionsAsync(It.IsAny<ListFunctionsRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ListFunctionsResponse()
+                {
+                    Functions = functions.ToList()
+                });
+
+            return fakeLambda.Object;
+        }
+
+        [Test]
+        public async Task AlarmCreatedWithCorrectProperties()
+        {
+            // arrange
+
+            var fakeStackDeployer = new FakeStackDeployer();
+
+            var dynamoClient = CreateDynamoClientForTables(new[]
+            {
+                new TableDescription()
+                {
+                    TableName = "first-dynamo-table",
+                    ProvisionedThroughput = new ProvisionedThroughputDescription()
+                    {
+                        ReadCapacityUnits = 100,
+                        WriteCapacityUnits = 200
+                    }
+                }
+            });
+
+            var lambdaClient = CreateLambdaClientForFunctions(new[]
+            {
+                new FunctionConfiguration()
+                {
+                    FunctionName = "first-lambda-function"
+                }
+            });
+
+            var creator = new CloudFormationAlarmCreator(fakeStackDeployer, new ConsoleAlarmLogger(true));
+
+            var config = ConfigHelper.CreateBasicConfiguration(
+                "test",
+                "group-suffix",
+                new Dictionary<string, AwsServiceAlarms>()
+                {
+                    {
+                        "DynamoDb", new AwsServiceAlarms()
+                        {
+                            Resources = new List<ResourceThresholds>()
+                            {
+                                new ResourceThresholds()
+                                {
+                                    Name = "first-dynamo-table"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "Lambda", new AwsServiceAlarms()
+                        {
+                            Resources = new List<ResourceThresholds>()
+                            {
+                                new ResourceThresholds()
+                                {
+                                    Name = "first-lambda-function"
+                                }
+                            }
+                        }
+                    }
+                }
+            );
+
+            var sutBuilder = new Builder(ConfigHelper.ConfigLoaderFor(config), creator);
+
+            sutBuilder.AddService(
+                new TableDescriptionSource(dynamoClient), 
+                new DynamoDbDataProvider(),
+                new DynamoDbDataProvider(),
+                WatchmanServiceConfigurationMapper.MapDynamoDb
+                );
+
+            sutBuilder.AddService(
+                new LambdaSource(lambdaClient),
+                new LambdaAlarmDataProvider(),
+                new LambdaAlarmDataProvider(),
+                WatchmanServiceConfigurationMapper.MapLambda
+                );
+
+            var sut = sutBuilder.Build();
+            
+            // act
+
+            await sut.LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            // assert
+
+            var alarmsByTable = fakeStackDeployer
+                .Stack("Watchman-test")
+                .AlarmsByDimension("TableName");
+
+            Assert.That(alarmsByTable.ContainsKey("first-dynamo-table"), Is.True);
+
+            var alarmsByFunction = fakeStackDeployer
+                .Stack("Watchman-test")
+                .AlarmsByDimension("FunctionName");
+
+            Assert.That(alarmsByFunction.ContainsKey("first-lambda-function"), Is.True);
+        }
+    }
+}


### PR DESCRIPTION
Trying to simplify the way config is passed around. This isn't perfect but I think it's better.

Previously individual alarms each had a reference to their alerting group and were passed into `CloudFormationAlarmCreator` one-by-one. It then had to group them back up by name in order to get them back into individual groups so that the alarms could be deployed in the correct stack. This was really messy and has been removed. So this change attempts to preserve the group -> alarm hierarchy as far as possible. Where grouping is required it is now done using `AlertingGroupParameters` that contains only the basic group properties and implements equality checking etc.

PR is quite big but most of the changes are tests.