### PR TITLE
Update StructureMap to 4.6

### DIFF
--- a/Quartermaster.Tests/Quartermaster.Tests.csproj
+++ b/Quartermaster.Tests/Quartermaster.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="StructureMap" Version="4.5.3" />
+    <PackageReference Include="StructureMap" Version="4.6.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Quartermaster/Quartermaster.csproj
+++ b/Quartermaster/Quartermaster.csproj
@@ -7,10 +7,10 @@
     <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
     <PackageReference Include="AWSSDK.Core" Version="3.3.21.6" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.5" />
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="CsvHelper" Version="6.1.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
-    <PackageReference Include="StructureMap" Version="4.5.3" />
+    <PackageReference Include="StructureMap" Version="4.6.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Watchman.Engine.Tests/Watchman.Engine.Tests.csproj
+++ b/Watchman.Engine.Tests/Watchman.Engine.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="StructureMap" Version="4.5.3" />
+    <PackageReference Include="StructureMap" Version="4.6.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Watchman.Tests/Watchman.Tests.csproj
+++ b/Watchman.Tests/Watchman.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="StructureMap" Version="4.5.3" />
+    <PackageReference Include="StructureMap" Version="4.6.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Watchman/Watchman.csproj
+++ b/Watchman/Watchman.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="AWSSDK.S3" Version="3.3.16.2" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.24" />
     <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2" />
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="StructureMap" Version="4.5.3" />
+    <PackageReference Include="StructureMap" Version="4.6.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Update StructureMap from 4.5 to 4.6
and CommandLineParser out of beta