### PR TITLE
Less generic configuration

### DIFF
--- a/Watchman.Configuration.Tests/Load/ConfigFileLoaderSimpleTests.cs
+++ b/Watchman.Configuration.Tests/Load/ConfigFileLoaderSimpleTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Watchman.Configuration.Load;
 using Moq;
@@ -132,7 +132,7 @@ namespace Watchman.Configuration.Tests.Load
             var group = _config.AlertingGroups.FirstOrDefault(g => g.Name == "AutoscalingOnly");
 
             Assert.That(group, Is.Not.Null);
-            AssertSectionIsPopulated(group.Services["AutoScaling"]);
+            AssertSectionIsPopulated(group.Services.AutoScaling);
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace Watchman.Configuration.Tests.Load
             var group = _config.AlertingGroups.FirstOrDefault(g => g.Name == "LambdaOnly");
 
             Assert.That(group, Is.Not.Null);
-            AssertSectionIsPopulated(group.Services["Lambda"]);
+            AssertSectionIsPopulated(group.Services.Lambda);
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace Watchman.Configuration.Tests.Load
             var group = _config.AlertingGroups.FirstOrDefault(g => g.Name == "RdsOnly");
 
             Assert.That(group, Is.Not.Null);
-            AssertSectionIsPopulated(group.Services["Rds"]);
+            AssertSectionIsPopulated(group.Services.Rds);
         }
 
         private static void AssertSectionIsPopulated(AwsServiceAlarms section)

--- a/Watchman.Configuration.Tests/Load/ConfigFileLoaderThresholdTests.cs
+++ b/Watchman.Configuration.Tests/Load/ConfigFileLoaderThresholdTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Watchman.Configuration.Load;
 using Moq;
@@ -73,7 +73,7 @@ namespace Watchman.Configuration.Tests.Load
             var group = _config.AlertingGroups.FirstOrDefault(g => g.Name == "LambdaTest");
 
             Assert.That(group, Is.Not.Null);
-            var section = group.Services["Lambda"];
+            var section = group.Services.Lambda;
 
             Assert.That(section, Is.Not.Null);
             Assert.That(section.ExcludeResourcesPrefixedWith, Is.Not.Null);
@@ -89,7 +89,7 @@ namespace Watchman.Configuration.Tests.Load
             var group = _config.AlertingGroups.FirstOrDefault(g => g.Name == "LambdaTest");
 
             Assert.That(group, Is.Not.Null);
-            var section = group.Services["Lambda"];
+            var section = group.Services.Lambda;
 
             Assert.That(section, Is.Not.Null);
             Assert.That(section.ExcludeResourcesPrefixedWith, Is.Not.Null);
@@ -106,7 +106,7 @@ namespace Watchman.Configuration.Tests.Load
             var group = _config.AlertingGroups.FirstOrDefault(g => g.Name == "LambdaTest");
 
             Assert.That(group, Is.Not.Null);
-            var values = group.Services["Lambda"].Values;
+            var values = group.Services.Lambda.Values;
 
             var errrorsHigh = values["ErrorsHigh"];
             var durationHigh = values["DurationHigh"];

--- a/Watchman.Configuration.Tests/Load/DuplicatesTests.cs
+++ b/Watchman.Configuration.Tests/Load/DuplicatesTests.cs
@@ -24,17 +24,6 @@ namespace Watchman.Configuration.Tests.Load
         }
 
         [Test]
-        public void LoadConfig_DuplicateSqsBlocks_Throws()
-        {
-            var loader = GetLoader("data\\duplicates\\Sqs");
-
-            var caught = Assert.Throws<ConfigException>(() => loader());
-
-            Assert.That(caught.InnerException, Is.Not.Null);
-            Assert.That(caught.InnerException.Message, Is.EqualTo("Sqs block can only defined once"));
-        }
-
-        [Test]
         public void LoadConfig_DuplicateGroupNames_Throws()
         {
             var loader = GetLoader("data\\duplicates\\duplicateGroups");

--- a/Watchman.Configuration.Tests/Validation/AwsServicesConfigValidatorTests.cs
+++ b/Watchman.Configuration.Tests/Validation/AwsServicesConfigValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Watchman.Configuration.Generic;
@@ -38,9 +38,9 @@ namespace Watchman.Configuration.Tests.Validation
             };
 
             _config = ConfigTestData.ValidConfig();
-            _config.AlertingGroups.First().Services = new Dictionary<string, AwsServiceAlarms>
+            _config.AlertingGroups.First().Services = new AlertingGroupServices()
             {
-                {"Lambda", _awsServiceAlarms}
+                Lambda = _awsServiceAlarms
             };
         }
 
@@ -137,14 +137,16 @@ namespace Watchman.Configuration.Tests.Validation
         public void AwsServicesConfig_OnlyResource_Passes()
         {
             // arrange
-            _config.AlertingGroups.First().Services.Clear();
-            _config.AlertingGroups.First().Services.Add("Lambda", new AwsServiceAlarms
+            _config.AlertingGroups.First().Services = new AlertingGroupServices()
             {
-                Resources = new List<ResourceThresholds>
+                Lambda = new AwsServiceAlarms
                 {
-                    new ResourceThresholds {Pattern = "ResourcePattern"}
+                    Resources = new List<ResourceThresholds>
+                    {
+                        new ResourceThresholds {Pattern = "ResourcePattern"}
+                    }
                 }
-            });
+            };
 
             // act
 

--- a/Watchman.Configuration.Tests/Validation/ConfigValidatorTests.cs
+++ b/Watchman.Configuration.Tests/Validation/ConfigValidatorTests.cs
@@ -26,18 +26,17 @@ namespace Watchman.Configuration.Tests.Validation
                     new Queue {Name = "QueueName"}
                 }
             };
-            _config.AlertingGroups.First().Services = new Dictionary<string, AwsServiceAlarms>
+            _config.AlertingGroups.First().Services = new AlertingGroupServices()
             {
+                AutoScaling = new AwsServiceAlarms
                 {
-                    "ServiceName", new AwsServiceAlarms
+                    Resources = new List<ResourceThresholds>
                     {
-                        Resources = new List<ResourceThresholds>
-                        {
-                            new ResourceThresholds {Pattern = "ResourceName"}
-                        }
+                        new ResourceThresholds {Pattern = "ResourceName"}
                     }
                 }
             };
+
         }
 
         [Test]
@@ -275,7 +274,7 @@ namespace Watchman.Configuration.Tests.Validation
             // arrange
             _config.AlertingGroups.First().DynamoDb.Tables = null;
             _config.AlertingGroups.First().Sqs = null;
-            _config.AlertingGroups.First().Services.Clear();
+            _config.AlertingGroups.First().Services = new AlertingGroupServices();
 
             // act
 
@@ -291,10 +290,11 @@ namespace Watchman.Configuration.Tests.Validation
             // arrange
             _config.AlertingGroups.First().DynamoDb = new DynamoDb();
             _config.AlertingGroups.First().Sqs = new Sqs();
-            _config.AlertingGroups.First().Services = new Dictionary<string, AwsServiceAlarms>
+            _config.AlertingGroups.First().Services = new AlertingGroupServices()
             {
-                {"someService", new AwsServiceAlarms()}
+                Lambda = new AwsServiceAlarms()
             };
+
             // act
 
             // assert
@@ -309,7 +309,13 @@ namespace Watchman.Configuration.Tests.Validation
             // arrange
             _config.AlertingGroups.First().DynamoDb.Tables = new List<Table>();
             _config.AlertingGroups.First().Sqs.Queues = new List<Queue>();
-            _config.AlertingGroups.First().Services.First().Value.Resources = new List<ResourceThresholds>();
+            _config.AlertingGroups.First().Services = new AlertingGroupServices()
+            {
+                Rds = new AwsServiceAlarms()
+                {
+                    Resources = new List<ResourceThresholds>()
+                }
+            };
 
             // act
 

--- a/Watchman.Configuration/AlertingGroup.cs
+++ b/Watchman.Configuration/AlertingGroup.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Watchman.Configuration.Generic;
 
 namespace Watchman.Configuration
 {
@@ -18,7 +17,7 @@ namespace Watchman.Configuration
         public DynamoDb DynamoDb { get; set; }
         public Sqs Sqs { get; set; }
 
-        public Dictionary<string, AwsServiceAlarms> Services { get; set; }
+        public AlertingGroupServices Services { get; set; }
 
         public AlertingGroup()
         {

--- a/Watchman.Configuration/AlertingGroupServices.cs
+++ b/Watchman.Configuration/AlertingGroupServices.cs
@@ -25,7 +25,7 @@ namespace Watchman.Configuration
             {"Rds", Rds},
             {"AutoScaling", AutoScaling},
             {"Lambda", Lambda},
-            {"VpsSubnet", VpcSubnet},
+            {"VpcSubnet", VpcSubnet},
             {"Elb", Elb},
             {"KinesisStream", KinesisStream},
             {"StepFunction", StepFunction},

--- a/Watchman.Configuration/AlertingGroupServices.cs
+++ b/Watchman.Configuration/AlertingGroupServices.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using Watchman.Configuration.Generic;
+
+namespace Watchman.Configuration
+{
+    public class AlertingGroupServices
+    {
+        public AwsServiceAlarms Rds { get; set;  }
+        public AwsServiceAlarms AutoScaling { get; set; }
+        public AwsServiceAlarms Lambda { get; set; }
+        public AwsServiceAlarms VpcSubnet { get; set; }
+        public AwsServiceAlarms Elb { get; set; }
+        public AwsServiceAlarms KinesisStream { get; set; }
+        public AwsServiceAlarms StepFunction { get; set; }
+        public AwsServiceAlarms DynamoDb { get; set; }
+
+        public IList<AwsServiceAlarms> AllServices => new[]
+                { Rds, AutoScaling, Lambda, VpcSubnet, Elb, KinesisStream, StepFunction, DynamoDb }
+            .Where(s => s != null)
+            .ToArray();
+
+        public Dictionary<string, AwsServiceAlarms> AllServicesByName => new Dictionary<string, AwsServiceAlarms>()
+        {
+            {"Rds", Rds},
+            {"AutoScaling", AutoScaling},
+            {"Lambda", Lambda},
+            {"VpsSubnet", VpcSubnet},
+            {"Elb", Elb},
+            {"KinesisStream", KinesisStream},
+            {"StepFunction", StepFunction},
+            {"DynamoDb", DynamoDb}
+        };
+    }
+}

--- a/Watchman.Configuration/Load/AlertingGroupConverter.cs
+++ b/Watchman.Configuration/Load/AlertingGroupConverter.cs
@@ -30,7 +30,7 @@ namespace Watchman.Configuration.Load
                 IsCatchAll = (bool)(jsonObject["IsCatchAll"] ?? false),
                 Name = (string)jsonObject["Name"],
                 ReportTargets = jsonObject["ReportTargets"]?.ToObject<List<ReportTarget>>(serializer) ?? new List<ReportTarget>(),
-                Services = new Dictionary<string, AwsServiceAlarms>()
+                Services = jsonObject["Services"]?.ToObject<AlertingGroupServices>(serializer)
             };
 
             if (jsonObject["Targets"] != null)
@@ -45,8 +45,6 @@ namespace Watchman.Configuration.Load
 
         private static void ReadServiceDefinitions(JObject jsonObject, AlertingGroup result, JsonSerializer serializer)
         {
-            var readSqs = false;
-
             if (jsonObject["DynamoDb"] != null)
             {
                 result.DynamoDb = jsonObject["DynamoDb"].ToObject<DynamoDb>(serializer);
@@ -55,29 +53,6 @@ namespace Watchman.Configuration.Load
             if (jsonObject["Sqs"] != null)
             {
                 result.Sqs = jsonObject["Sqs"].ToObject<Sqs>(serializer);
-                readSqs = true;
-            }
-
-            var allServices = (JObject) jsonObject["Services"];
-            if (allServices != null)
-            {
-                foreach (var prop in allServices)
-                {
-                 
-                    if (prop.Key == "Sqs")
-                    {
-                        if (readSqs)
-                        {
-                            throw new JsonReaderException("Sqs block can only defined once");
-                        }
-
-                        result.Sqs = prop.Value.ToObject<Sqs>(serializer);
-                    }
-                    else
-                    {
-                        result.Services[prop.Key] = prop.Value.ToObject<AwsServiceAlarms>(serializer);
-                    }
-                }
             }
         }
 

--- a/Watchman.Configuration/Load/ConfigLoader.cs
+++ b/Watchman.Configuration/Load/ConfigLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -126,7 +126,7 @@ namespace Watchman.Configuration.Load
         {
             var tableCount = group.DynamoDb.Tables?.Count ?? 0;
             var queueCount = group.Sqs.Queues?.Count ?? 0;
-            var serviceCount = CountGenericServices(group);
+            var serviceCount = group.Services?.AllServices?.Count ?? 0;
 
             if ((tableCount == 0) && (queueCount == 0) && (serviceCount == 0))
             {
@@ -152,19 +152,6 @@ namespace Watchman.Configuration.Load
 
             return string.Join(", ", items);
         }
-
-        private static int CountGenericServices(AlertingGroup group)
-        {
-            if (group.Services == null)
-            {
-                return 0;
-            }
-
-            return group.Services.Values
-                .Select(v => v.Resources?.Count ?? 0)
-                .Sum();
-        }
-
         private static string DescribeTable(Table table)
         {
             string description;

--- a/Watchman.Configuration/Validation/AwsServiceValidation.cs
+++ b/Watchman.Configuration/Validation/AwsServiceValidation.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Watchman.Configuration.Generic;
 
 namespace Watchman.Configuration.Validation
@@ -15,9 +15,12 @@ namespace Watchman.Configuration.Validation
                 }
             }
 
-            foreach (var resource in serviceAlarms.Resources)
+            if (serviceAlarms.Resources != null)
             {
-                ValidateResource(alertingGroupName, serviceName, resource);
+                foreach (var resource in serviceAlarms.Resources)
+                {
+                    ValidateResource(alertingGroupName, serviceName, resource);
+                }
             }
         }
 

--- a/Watchman.Configuration/Validation/ConfigValidator.cs
+++ b/Watchman.Configuration/Validation/ConfigValidator.cs
@@ -74,14 +74,18 @@ namespace Watchman.Configuration.Validation
                 SqsValidation.Validate(alertingGroup.Name, alertingGroup.Sqs);
             }
 
-            if (HasAny(alertingGroup.Services))
+            if (alertingGroup.Services != null)
             {
-                foreach (var service in alertingGroup.Services)
+                foreach (var service in alertingGroup.Services.AllServicesByName)
                 {
-                    if (HasAny(service.Value?.Resources))
+                    if (service.Value != null)
                     {
-                        hasAtLeastOneResource = true;
                         AwsServiceValidation.Validate(alertingGroup.Name, service.Key, service.Value);
+
+                        if (HasAny(service.Value.Resources))
+                        {
+                            hasAtLeastOneResource = true;
+                        }
                     }
                 }
             }

--- a/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
+++ b/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
@@ -9,62 +9,52 @@ namespace Watchman.Engine.Generation
 {
     public static class WatchmanServiceConfigurationMapper
     {
-        private static AwsServiceAlarms GetService(AlertingGroup group, string serviceIdentifier)
-        {
-            if (!group.Services.ContainsKey(serviceIdentifier))
-            {
-                return null;
-            }
-
-            return group.Services[serviceIdentifier];
-        }
-
         public static WatchmanServiceConfiguration MapRds(WatchmanConfiguration input)
         {
             const string id = "Rds";
-            return Map(input, id, a => GetService(a, id), Defaults.Rds);
+            return Map(input, id, a => a?.Services?.Rds, Defaults.Rds);
         }
 
         public static WatchmanServiceConfiguration MapAutoScaling(WatchmanConfiguration input)
         {
             const string id = "AutoScaling";
-            return Map(input, id, a => GetService(a, id), Defaults.AutoScaling);
+            return Map(input, id, a => a?.Services?.AutoScaling, Defaults.AutoScaling);
         }
 
         public static WatchmanServiceConfiguration MapLambda(WatchmanConfiguration input)
         {
             const string id = "Lambda";
-            return Map(input,id, a => GetService(a, id), Defaults.Lambda);
+            return Map(input,id, a => a?.Services?.Lambda, Defaults.Lambda);
         }
 
         public static WatchmanServiceConfiguration MapVpcSubnet(WatchmanConfiguration input)
         {
             const string id = "VpcSubnet";
-            return Map(input, id, a => GetService(a, id), Defaults.VpcSubnets);
+            return Map(input, id, a => a?.Services?.VpcSubnet, Defaults.VpcSubnets);
         }
 
         public static WatchmanServiceConfiguration MapElb(WatchmanConfiguration input)
         {
             const string id = "Elb";
-            return Map(input, id, a => GetService(a, id), Defaults.Elb);
+            return Map(input, id, a => a?.Services?.Elb, Defaults.Elb);
         }
 
         public static WatchmanServiceConfiguration MapStream(WatchmanConfiguration input)
         {
             const string id = "KinesisStream";
-            return Map(input, id, a => GetService(a, id), Defaults.KinesisStream);
+            return Map(input, id, a => a?.Services?.KinesisStream, Defaults.KinesisStream);
         }
 
         public static WatchmanServiceConfiguration MapStepFunction(WatchmanConfiguration input)
         {
             const string id = "StepFunction";
-            return Map(input, id, a => GetService(a, id), Defaults.StepFunction);
+            return Map(input, id, a => a?.Services?.StepFunction, Defaults.StepFunction);
         }
 
         public static WatchmanServiceConfiguration MapDynamoDb(WatchmanConfiguration input)
         {
             const string id = "DynamoDb";
-            return Map(input, id, a => GetService(a, id), Defaults.DynamoDb);
+            return Map(input, id, a => a?.Services?.DynamoDb, Defaults.DynamoDb);
         }
 
         private static WatchmanServiceConfiguration Map(WatchmanConfiguration input,

--- a/Watchman.Tests/ConfigHelper.cs
+++ b/Watchman.Tests/ConfigHelper.cs
@@ -11,27 +11,7 @@ namespace Watchman.Tests
         public static WatchmanConfiguration CreateBasicConfiguration(
             string name,
             string suffix,
-            string serviceName,
-            List<ResourceThresholds> resources
-        )
-        {
-            return CreateBasicConfiguration(name,
-                suffix,
-                new Dictionary<string, AwsServiceAlarms>()
-                {
-                    {
-                        serviceName, new AwsServiceAlarms()
-                        {
-                            Resources = resources
-                        }
-                    }
-                });
-        }
-
-        public static WatchmanConfiguration CreateBasicConfiguration(
-            string name,
-            string suffix,
-            Dictionary<string, AwsServiceAlarms> services
+            AlertingGroupServices services
         )
         {
             return new WatchmanConfiguration()

--- a/Watchman.Tests/Dynamo/DynamoAlarmTests.cs
+++ b/Watchman.Tests/Dynamo/DynamoAlarmTests.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Watchman.AwsResources.Services.DynamoDb;
+using Watchman.Configuration;
 using Watchman.Configuration.Generic;
 using Watchman.Engine;
 using Watchman.Engine.Generation;
@@ -44,13 +45,20 @@ namespace Watchman.Tests.Dynamo
 
             var creator = new CloudFormationAlarmCreator(stack.Object, new ConsoleAlarmLogger(true));
 
-            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix", "DynamoDb", new List<ResourceThresholds>()
-            {
-                new ResourceThresholds()
+            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix",
+                new AlertingGroupServices()
                 {
-                    Name = "non-existant-table"
-                }
-            });
+                    DynamoDb = new AwsServiceAlarms()
+                    {
+                        Resources = new List<ResourceThresholds>()
+                        {
+                            new ResourceThresholds()
+                            {
+                                Name = "non-existant-table"
+                            }
+                        }
+                    }
+                });
 
             var sut = IoCHelper.CreateSystemUnderTest(
                 source, 
@@ -100,11 +108,17 @@ namespace Watchman.Tests.Dynamo
             var source = new TableDescriptionSource(dynamoClient);
             var creator = new CloudFormationAlarmCreator(stack, new ConsoleAlarmLogger(true));
 
-            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix", "DynamoDb", new List<ResourceThresholds>()
+            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix", new AlertingGroupServices()
             {
-                new ResourceThresholds()
+                DynamoDb = new AwsServiceAlarms()
                 {
-                    Name = "first-dynamo-table"
+                    Resources = new List<ResourceThresholds>()
+                    {
+                        new ResourceThresholds()
+                        {
+                            Name = "first-dynamo-table"
+                        }
+                    }
                 }
             });
 

--- a/Watchman.Tests/MultipleServiceAlarmTests.cs
+++ b/Watchman.Tests/MultipleServiceAlarmTests.cs
@@ -15,6 +15,7 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Watchman.AwsResources.Services.DynamoDb;
 using Watchman.AwsResources.Services.Lambda;
+using Watchman.Configuration;
 using Watchman.Configuration.Generic;
 using Watchman.Engine;
 using Watchman.Engine.Generation;
@@ -59,29 +60,25 @@ namespace Watchman.Tests
             var config = ConfigHelper.CreateBasicConfiguration(
                 "test",
                 "group-suffix",
-                new Dictionary<string, AwsServiceAlarms>()
+                new AlertingGroupServices()
                 {
+                    DynamoDb = new AwsServiceAlarms()
                     {
-                        "DynamoDb", new AwsServiceAlarms()
+                        Resources = new List<ResourceThresholds>()
                         {
-                            Resources = new List<ResourceThresholds>()
+                            new ResourceThresholds()
                             {
-                                new ResourceThresholds()
-                                {
-                                    Name = "first-dynamo-table"
-                                }
+                                Name = "first-dynamo-table"
                             }
                         }
                     },
+                    Lambda = new AwsServiceAlarms()
                     {
-                        "Lambda", new AwsServiceAlarms()
+                        Resources = new List<ResourceThresholds>()
                         {
-                            Resources = new List<ResourceThresholds>()
+                            new ResourceThresholds()
                             {
-                                new ResourceThresholds()
-                                {
-                                    Name = "first-lambda-function"
-                                }
+                                Name = "first-lambda-function"
                             }
                         }
                     }


### PR DESCRIPTION
Make the configuration objects less generic for the newer services. This will eventually allow us to have per-service configuration - e.g. for autoscaling we might want to specify a delay for increasing the desired instances threshold so that instances have time to start.

The next step will be for `AwsServiceAlarms` to take a type argument representing the additional configuration properties. E.g. something like `AwsServiceAlarms<AutoScalingAlarmConfiguration>`