### PR TITLE
Monitor dynamo indexes, use correct calc. for new table alarms impl

### DIFF
--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -104,7 +104,7 @@ The following services are supported
 - `Kinesis`
 - `Elb`
 - `StepFunction`
-- `DynamoDb` (in-progress migration from the existing non-cloudformation mechanism, limited functionality - indexes are not yet monitored.)
+- `DynamoDb` (new implementation of the existing non-cloudformation mechanism)
 - `VpcSubnet` (this is a custom service using JUST EAT custom metrics)
 
 ## Alarm names and default thresholds

--- a/Watchman.AwsResources/Services/DynamoDb/DynamoDbGsiDataProvider.cs
+++ b/Watchman.AwsResources/Services/DynamoDb/DynamoDbGsiDataProvider.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Amazon.CloudWatch.Model;
 using Amazon.DynamoDBv2.Model;
@@ -9,26 +8,24 @@ using Watchman.Configuration.Generic;
 
 namespace Watchman.AwsResources.Services.DynamoDb
 {
-    public class DynamoDbDataProvider : IAlarmDimensionProvider<TableDescription>,
-        IResourceAttributesProvider<TableDescription, ResourceConfig>
+    public class DynamoDbGsiDataProvider : IAlarmDimensionProvider<GlobalSecondaryIndexDescription>,
+        IResourceAttributesProvider<GlobalSecondaryIndexDescription, ResourceConfig>
     {
-        public List<Dimension> GetDimensions(TableDescription resource, IList<string> dimensionNames)
+        public List<Dimension> GetDimensions(GlobalSecondaryIndexDescription resource, IList<string> dimensionNames)
         {
             var allowed = new List<Dimension>()
             {
                 new Dimension()
                 {
-                    Name = "TableName",
-                    Value = resource.TableName
+                    Name = "GlobalSecondaryIndexName",
+                    Value = resource.IndexName
                 }
             };
 
             var requested = dimensionNames
                 .Join(allowed, name => name, dim => dim.Name, (_, dim) => dim)
                 .ToList();
-
             
-
             if (requested.Count != dimensionNames.Count)
             {
                 var missing = dimensionNames
@@ -43,7 +40,7 @@ namespace Watchman.AwsResources.Services.DynamoDb
 
         private const int OneMinuteInSeconds = 60;
 
-        public Task<decimal> GetValue(TableDescription resource, ResourceConfig config, string property)
+        public Task<decimal> GetValue(GlobalSecondaryIndexDescription resource, ResourceConfig config, string property)
         {
             // in future the multiplication by a minute shouldn't be hardcoded
             // it's needed because the read capacity unit is in seconds, but our alarm is currently a sum over 1 minute. 

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -366,6 +366,76 @@ namespace Watchman.Engine.Alarms
             }
         };
 
+        public static IList<AlarmDefinition> DynamoDbGsi = new List<AlarmDefinition>()
+        {
+            new AlarmDefinition
+            {
+                Name = "GsiConsumedReadCapacityUnitsHigh",
+                Metric = "ConsumedReadCapacityUnits",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.PercentageOf,
+                    Value = AwsConstants.DefaultCapacityThreshold * 100,
+                    SourceAttribute = "ProvisionedReadThroughput"
+                },
+                DimensionNames = new[] {"GlobalSecondaryIndexName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            },
+            new AlarmDefinition
+            {
+                Name = "GsiConsumedWriteCapacityUnitsHigh",
+                Metric = "ConsumedWriteCapacityUnits",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.PercentageOf,
+                    Value = AwsConstants.DefaultCapacityThreshold * 100,
+                    SourceAttribute = "ProvisionedWriteThroughput"
+                },
+                DimensionNames = new[] {"GlobalSecondaryIndexName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            },
+            new AlarmDefinition
+            {
+                Name = "GsiReadThrottleEventsHigh",
+                Metric = "ReadThrottleEvents",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.ThrottlingThreshold
+                },
+                DimensionNames = new[] {"GlobalSecondaryIndexName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            },
+            new AlarmDefinition
+            {
+                Name = "GsiWriteThrottleEventsHigh",
+                Metric = "WriteThrottleEvents",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.ThrottlingThreshold
+                },
+                DimensionNames = new[] {"GlobalSecondaryIndexName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            }
+        };
+
         public static IList<AlarmDefinition> DynamoDb = new List<AlarmDefinition>
         {
             new AlarmDefinition

--- a/Watchman.Engine/Generation/AlarmBuilder.cs
+++ b/Watchman.Engine/Generation/AlarmBuilder.cs
@@ -115,10 +115,5 @@ namespace Watchman.Engine.Generation
 
             return threshold;
         }
-
-        public string GetAlarmName(AwsResource<T> resource, string alertName, string groupSuffix)
-        {
-            return $"{resource.Name}-{alertName}-{groupSuffix}";
-        }
     }
 }

--- a/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
@@ -10,7 +10,7 @@ using Watchman.Engine.Alarms;
 
 namespace Watchman.Engine.Generation.Dynamo
 {
-    public class DynamoResourceAlarmGenerator : IResourceAlarmGenerator<ResourceConfig>
+    public class DynamoResourceAlarmGenerator : IResourceAlarmGenerator<TableDescription, ResourceConfig>
     {
         private readonly IResourceSource<TableDescription> _tableSource;
         private readonly IAlarmDimensionProvider<TableDescription> _dimensions;

--- a/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.Model;
+using Watchman.AwsResources;
+using Watchman.AwsResources.Services.DynamoDb;
+using Watchman.Configuration.Generic;
+using Watchman.Engine.Alarms;
+
+namespace Watchman.Engine.Generation.Dynamo
+{
+    public class DynamoResourceAlarmGenerator : IResourceAlarmGenerator<ResourceConfig>
+    {
+        private readonly IResourceSource<TableDescription> _tableSource;
+        private readonly IAlarmDimensionProvider<TableDescription> _dimensions;
+        private readonly IAlarmDimensionProvider<GlobalSecondaryIndexDescription> _gsiDimensionProvider = new DynamoDbGsiDataProvider();
+        private readonly AlarmBuilder<TableDescription, ResourceConfig> _builder;
+        private readonly AlarmBuilder<GlobalSecondaryIndexDescription, ResourceConfig> _gsiAlarmBuilder = new AlarmBuilder<GlobalSecondaryIndexDescription, ResourceConfig>(new DynamoDbGsiDataProvider());
+
+        public DynamoResourceAlarmGenerator(
+            IResourceSource<TableDescription> tableSource,
+            IAlarmDimensionProvider<TableDescription> dimensionProvider,
+            IResourceAttributesProvider<TableDescription, ResourceConfig> attributeProvider)
+        {
+            _tableSource = tableSource;
+            _dimensions = dimensionProvider;
+            _builder = new AlarmBuilder<TableDescription, ResourceConfig>(attributeProvider);
+        }
+
+        public async Task<IList<Alarm>>  GenerateAlarmsFor(
+            AwsServiceAlarms<ResourceConfig> service,
+            IList<AlarmDefinition> defaults,
+            string alarmSuffix)
+        {
+            if (service?.Resources == null || service.Resources.Count == 0)
+            {
+                return new List<Alarm>();
+            }
+            
+            List<Alarm> alarms = new List<Alarm>();
+
+            foreach (var resource in service.Resources)
+            {
+                var alarmsForResource = await CreateAlarmsForResource(defaults, resource, service, alarmSuffix);
+                alarms.AddRange(alarmsForResource);                    
+            }
+
+            return alarms;
+        }
+
+        private async Task<IList<Alarm>> CreateAlarmsForResource(
+            IList<AlarmDefinition> defaults,
+            ResourceThresholds<ResourceConfig> resource,
+            AwsServiceAlarms<ResourceConfig> service,
+            string groupSuffix)
+        {
+            var entity = await _tableSource.GetResourceAsync(resource.Name);
+
+            if (entity == null)
+            {
+                throw new Exception($"Entity {resource.Name} not found");
+            }
+
+            var result = await BuildTableAlarms(defaults, resource, service, groupSuffix, entity);
+            
+            result.AddRange(await BuildIndexAlarms(resource, service, groupSuffix, entity));
+
+            return result;
+        }
+
+        private async Task<List<Alarm>> BuildTableAlarms(IList<AlarmDefinition> defaults, ResourceThresholds<ResourceConfig> resource, AwsServiceAlarms<ResourceConfig> service, string groupSuffix,
+            AwsResource<TableDescription> entity)
+        {
+            var expanded = await _builder.CopyAndUpdateDefaultAlarmsForResource(entity, defaults, service, resource);
+
+            var result = new List<Alarm>();
+
+            foreach (var alarm in expanded)
+            {
+                var dimensions = _dimensions.GetDimensions(entity.Resource, alarm.DimensionNames);
+
+                var model = new Alarm
+                {
+                    AlarmName = $"{resource.Name}-{alarm.Name}-{groupSuffix}",
+                    Resource = entity,
+                    Dimensions = dimensions,
+                    AlarmDefinition = alarm
+                };
+                result.Add(model);
+            }
+            return result;
+        }
+
+        private async Task<IList<Alarm>> BuildIndexAlarms(ResourceThresholds<ResourceConfig> resource, AwsServiceAlarms<ResourceConfig> service, string groupSuffix,
+            AwsResource<TableDescription> entity)
+        {
+            var result = new List<Alarm>();
+
+            var gsiSet = entity.Resource.GlobalSecondaryIndexes;
+
+
+            foreach (var gsi in gsiSet)
+            {
+                var gsiResource = new AwsResource<GlobalSecondaryIndexDescription>(gsi.IndexName, gsi);
+
+
+                var expandedGsi = await _gsiAlarmBuilder.CopyAndUpdateDefaultAlarmsForResource(
+                    gsiResource,
+                    Defaults.DynamoDbGsi, service, resource);
+
+                foreach (var gsiAlarm in expandedGsi)
+                {
+                    var dimensions = _gsiDimensionProvider.GetDimensions(gsi, gsiAlarm.DimensionNames);
+
+                    var model = new Alarm
+                    {
+                        AlarmName = $"{resource.Name}-{gsi.IndexName}-{gsiAlarm.Name}-{groupSuffix}",
+                        Resource = entity,
+                        Dimensions = dimensions,
+                        AlarmDefinition = gsiAlarm
+                    };
+
+                    result.Add(model);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Watchman.Engine/Generation/IResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/IResourceAlarmGenerator.cs
@@ -4,7 +4,10 @@ using Watchman.Configuration.Generic;
 
 namespace Watchman.Engine.Generation
 {
-    public interface IResourceAlarmGenerator<TAlarmConfig> where TAlarmConfig : class, IServiceAlarmConfig<TAlarmConfig>, new()
+    // TResource type argument is required because the implementations of this are specific to TResource (not necessarily TAlarmConfig)
+    public interface IResourceAlarmGenerator<TResource, TAlarmConfig>
+        where TAlarmConfig : class, IServiceAlarmConfig<TAlarmConfig>, new()
+        where TResource : class
     {
         Task<IList<Alarm>> GenerateAlarmsFor(AwsServiceAlarms<TAlarmConfig> service, IList<AlarmDefinition> defaults, string alarmSuffix);
     }

--- a/Watchman.Engine/Generation/ResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/ResourceAlarmGenerator.cs
@@ -69,7 +69,7 @@ namespace Watchman.Engine.Generation
 
                 var model = new Alarm
                 {
-                    AlarmName = _builder.GetAlarmName(entity, alarm.Name, groupSuffix),
+                    AlarmName = $"{resource.Name}-{alarm.Name}-{groupSuffix}",
                     Resource = entity,
                     Dimensions = dimensions,
                     AlarmDefinition = alarm

--- a/Watchman.Engine/Generation/ResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/ResourceAlarmGenerator.cs
@@ -6,7 +6,7 @@ using Watchman.Configuration.Generic;
 
 namespace Watchman.Engine.Generation
 {
-    public class ResourceAlarmGenerator<T, TAlarmConfig> : IResourceAlarmGenerator<TAlarmConfig>
+    public class ResourceAlarmGenerator<T, TAlarmConfig> : IResourceAlarmGenerator<T, TAlarmConfig>
         where T:class
         where TAlarmConfig : class, IServiceAlarmConfig<TAlarmConfig>, new()
     {

--- a/Watchman.Engine/Generation/ServiceAlarmTasks.cs
+++ b/Watchman.Engine/Generation/ServiceAlarmTasks.cs
@@ -18,7 +18,7 @@ namespace Watchman.Engine.Generation
         private readonly ResourceNamePopulator<T, TAlarmConfig> _populator;
         private readonly OrphanResourcesReporter<T> _orphansReporter;
         private readonly IAlarmCreator _creator;
-        private readonly IResourceAlarmGenerator<TAlarmConfig> _resourceAlarmGenerator;
+        private readonly IResourceAlarmGenerator<T, TAlarmConfig> _resourceAlarmGenerator;
         private readonly Func<WatchmanConfiguration, WatchmanServiceConfiguration<TAlarmConfig>> _serviceConfigMapper;
 
         public ServiceAlarmTasks(
@@ -26,7 +26,7 @@ namespace Watchman.Engine.Generation
             ResourceNamePopulator<T, TAlarmConfig> populator,
             OrphanResourcesReporter<T> orphansReporter,
             IAlarmCreator creator,
-            IResourceAlarmGenerator<TAlarmConfig> resourceAlarmGenerator,
+            IResourceAlarmGenerator<T, TAlarmConfig> resourceAlarmGenerator,
             Func<WatchmanConfiguration, WatchmanServiceConfiguration<TAlarmConfig>> serviceConfigMapper)
         {
             _populator = populator;

--- a/Watchman.Engine/Generation/ServiceAlarmTasks.cs
+++ b/Watchman.Engine/Generation/ServiceAlarmTasks.cs
@@ -18,7 +18,7 @@ namespace Watchman.Engine.Generation
         private readonly ResourceNamePopulator<T, TAlarmConfig> _populator;
         private readonly OrphanResourcesReporter<T> _orphansReporter;
         private readonly IAlarmCreator _creator;
-        private readonly ResourceAlarmGenerator<T, TAlarmConfig> _resourceAlarmGenerator;
+        private readonly IResourceAlarmGenerator<TAlarmConfig> _resourceAlarmGenerator;
         private readonly Func<WatchmanConfiguration, WatchmanServiceConfiguration<TAlarmConfig>> _serviceConfigMapper;
 
         public ServiceAlarmTasks(
@@ -26,7 +26,7 @@ namespace Watchman.Engine.Generation
             ResourceNamePopulator<T, TAlarmConfig> populator,
             OrphanResourcesReporter<T> orphansReporter,
             IAlarmCreator creator,
-            ResourceAlarmGenerator<T, TAlarmConfig> resourceAlarmGenerator,
+            IResourceAlarmGenerator<TAlarmConfig> resourceAlarmGenerator,
             Func<WatchmanConfiguration, WatchmanServiceConfiguration<TAlarmConfig>> serviceConfigMapper)
         {
             _populator = populator;

--- a/Watchman.Tests/Dynamo/DynamoAlarmTests.cs
+++ b/Watchman.Tests/Dynamo/DynamoAlarmTests.cs
@@ -1,14 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Moq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using Watchman.AwsResources;
 using Watchman.AwsResources.Services.DynamoDb;
 using Watchman.Configuration;
 using Watchman.Configuration.Generic;
@@ -22,6 +18,8 @@ namespace Watchman.Tests.Dynamo
 {
     public class DynamoAlarmTests
     {
+        private const int OneMinuteInSeconds = 60;
+
         [Test]
         public async Task IgnoresNamedEntitiesThatDoNotExist()
         {
@@ -61,19 +59,19 @@ namespace Watchman.Tests.Dynamo
                     }
                 });
 
-            var sut = IoCHelper.CreateSystemUnderTest(
-                source, 
-                new DynamoDbDataProvider(), 
+            var builder = new Builder(ConfigHelper.ConfigLoaderFor(config), creator);
+            builder.AddDynamoDbService(source,
                 new DynamoDbDataProvider(),
-                WatchmanServiceConfigurationMapper.MapDynamoDb,
-                creator, 
-                ConfigHelper.ConfigLoaderFor(config)
-                );
+                new DynamoDbDataProvider(),
+                WatchmanServiceConfigurationMapper.MapDynamoDb
+            );
 
-            
+            var sut = builder.Build();
+
+
 
             // act
-            
+
             await sut.LoadAndGenerateAlarms(RunMode.GenerateAlarms);
             
             // assert
@@ -93,7 +91,7 @@ namespace Watchman.Tests.Dynamo
 
             var stack = new FakeStackDeployer();
 
-            var dynamoClient =  FakeAwsClients.CreateDynamoClientForTables(new[]
+            var dynamoClient = FakeAwsClients.CreateDynamoClientForTables(new[]
             {
                 new TableDescription()
                 {
@@ -123,13 +121,14 @@ namespace Watchman.Tests.Dynamo
                 }
             });
 
-            var sut = IoCHelper.CreateSystemUnderTest(
-                source,
+            var builder = new Builder(ConfigHelper.ConfigLoaderFor(config), creator);
+            builder.AddDynamoDbService(source,
                 new DynamoDbDataProvider(),
                 new DynamoDbDataProvider(),
-                WatchmanServiceConfigurationMapper.MapDynamoDb,
-                creator, ConfigHelper.ConfigLoaderFor(config)
-            );
+                WatchmanServiceConfigurationMapper.MapDynamoDb
+                );
+
+            var sut = builder.Build();
             
             // act
 
@@ -137,7 +136,8 @@ namespace Watchman.Tests.Dynamo
 
             // assert
 
-            const decimal defaultCapacityThresholdFraction = 0.8m;
+            const decimal defaultCapacityThreshold = 0.8m;
+            const decimal capacityMultiplier = defaultCapacityThreshold * OneMinuteInSeconds;
             const int defaultThrottleThreshold = 2;
 
             var alarmsByTable = stack
@@ -152,7 +152,7 @@ namespace Watchman.Tests.Dynamo
                     alarm.Properties["MetricName"].Value<string>() == "ConsumedReadCapacityUnits"
                     && alarm.Properties["AlarmName"].Value<string>().Contains("ConsumedReadCapacityUnitsHigh")
                     && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
-                    && alarm.Properties["Threshold"].Value<int>() == 100 * defaultCapacityThresholdFraction
+                    && alarm.Properties["Threshold"].Value<int>() == 100 * capacityMultiplier
                     && alarm.Properties["Period"].Value<int>() == 60
                     && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                     && alarm.Properties["Statistic"].Value<string>() == "Sum"
@@ -165,7 +165,7 @@ namespace Watchman.Tests.Dynamo
                     alarm.Properties["MetricName"].Value<string>() == "ConsumedWriteCapacityUnits"
                     && alarm.Properties["AlarmName"].Value<string>().Contains("ConsumedWriteCapacityUnitsHigh")
                     && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
-                    && alarm.Properties["Threshold"].Value<int>() == 200 * defaultCapacityThresholdFraction
+                    && alarm.Properties["Threshold"].Value<int>() == 200 * capacityMultiplier
                     && alarm.Properties["Period"].Value<int>() == 60
                     && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                     && alarm.Properties["Statistic"].Value<string>() == "Sum"
@@ -185,6 +185,136 @@ namespace Watchman.Tests.Dynamo
                     && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.DynamoDb
                 )
             );
+        }
+
+        [Test]
+        public async Task AlarmsCanBeAddedToGlobalSecondaryIndexes()
+        {
+            // arrange
+
+            var stack = new FakeStackDeployer();
+
+            var dynamoClient = FakeAwsClients.CreateDynamoClientForTables(new[]
+            {
+                new TableDescription()
+                {
+                    TableName = "first-table",
+                    ProvisionedThroughput = new ProvisionedThroughputDescription()
+                    {
+                        ReadCapacityUnits = 100,
+                        WriteCapacityUnits = 200
+                    },
+                    GlobalSecondaryIndexes = new List<GlobalSecondaryIndexDescription>()
+                    {
+                        new GlobalSecondaryIndexDescription()
+                        {
+                             IndexName = "first-gsi",
+                             ProvisionedThroughput = new ProvisionedThroughputDescription()
+                             {
+                                 ReadCapacityUnits = 400,
+                                 WriteCapacityUnits = 500
+                             }
+                        }
+                    }
+                }
+            });
+
+            var source = new TableDescriptionSource(dynamoClient);
+            var creator = new CloudFormationAlarmCreator(stack, new ConsoleAlarmLogger(true));
+
+            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix", new AlertingGroupServices()
+            {
+                DynamoDb = new AwsServiceAlarms<ResourceConfig>()
+                {
+                    Resources =
+                        new List<ResourceThresholds<ResourceConfig>>()
+                        {
+                            new ResourceThresholds<ResourceConfig>()
+                            {
+                                Name = "first-table"
+                            }
+                        }
+                }
+            });
+
+            var builder = new Builder(ConfigHelper.ConfigLoaderFor(config), creator);
+            builder.AddDynamoDbService(source,
+                new DynamoDbDataProvider(),
+                new DynamoDbDataProvider(),
+                WatchmanServiceConfigurationMapper.MapDynamoDb
+            );
+
+            var sut = builder.Build();
+
+            // act
+
+            await sut.LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            // assert
+            const decimal defaultCapacityThreshold = 0.8m;
+            const decimal capacityMultiplier = defaultCapacityThreshold * OneMinuteInSeconds;
+            const int defaultThrottleThreshold = 2;
+
+            // basic check we still have table alarms
+            Assert.That(stack.Stack("Watchman-test").AlarmsByDimension("TableName").Any(), Is.True);
+
+            var alarmsByGsi = stack
+                .Stack("Watchman-test")
+                .AlarmsByDimension("GlobalSecondaryIndexName");
+
+            Assert.That(alarmsByGsi.ContainsKey("first-gsi"), Is.True);
+            var alarms = alarmsByGsi["first-gsi"];
+
+            var consumedRead = alarms.SingleOrDefault(
+                a => a.Properties["AlarmName"].ToString()
+                    .Contains("first-table-first-gsi-GsiConsumedReadCapacityUnitsHigh"));
+            Assert.That(consumedRead, Is.Not.Null, "GSI read alarm missing");
+            Assert.That(consumedRead.Properties["MetricName"].Value<string>(), Is.EqualTo("ConsumedReadCapacityUnits"));
+            Assert.That(consumedRead.Properties["Threshold"].Value<int>(),
+                Is.EqualTo(400 * capacityMultiplier));
+            Assert.That(consumedRead.Properties["Period"].Value<int>(), Is.EqualTo(60));
+            Assert.That(consumedRead.Properties["ComparisonOperator"].Value<string>(),
+                Is.EqualTo("GreaterThanOrEqualToThreshold"));
+            Assert.That(consumedRead.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
+            Assert.That(consumedRead.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+            
+            var consumedWrite = alarms.SingleOrDefault(
+                a => a.Properties["AlarmName"].ToString()
+                    .Contains("first-table-first-gsi-GsiConsumedWriteCapacityUnitsHigh"));
+            Assert.That(consumedWrite, Is.Not.Null, "GSI write alarm missing");
+            Assert.That(consumedWrite.Properties["MetricName"].Value<string>(),
+                Is.EqualTo("ConsumedWriteCapacityUnits"));
+            Assert.That(consumedWrite.Properties["Threshold"].Value<int>(),
+                Is.EqualTo(500 * capacityMultiplier));
+            Assert.That(consumedWrite.Properties["Period"].Value<int>(), Is.EqualTo(60));
+            Assert.That(consumedWrite.Properties["ComparisonOperator"].Value<string>(),
+                Is.EqualTo("GreaterThanOrEqualToThreshold"));
+            Assert.That(consumedWrite.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
+            Assert.That(consumedWrite.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+
+            var readThrottle = alarms.SingleOrDefault(
+                a => a.Properties["AlarmName"].ToString()
+                    .Contains("first-table-first-gsi-GsiReadThrottleEventsHigh"));
+            Assert.That(readThrottle, Is.Not.Null, "GSI read throttle alarm missing");
+            Assert.That(readThrottle.Properties["MetricName"].Value<string>(), Is.EqualTo("ReadThrottleEvents"));
+            Assert.That(readThrottle.Properties["Threshold"].Value<int>(), Is.EqualTo(defaultThrottleThreshold));
+            Assert.That(readThrottle.Properties["Period"].Value<int>(), Is.EqualTo(60));
+            Assert.That(readThrottle.Properties["ComparisonOperator"].Value<string>(),
+                Is.EqualTo("GreaterThanOrEqualToThreshold"));
+            Assert.That(readThrottle.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
+            Assert.That(readThrottle.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+            
+            var writeThrottle = alarms.SingleOrDefault(
+                a => a.Properties["AlarmName"].ToString()
+                    .Contains("first-table-first-gsi-GsiWriteThrottleEventsHigh"));
+            Assert.That(writeThrottle, Is.Not.Null, "GSI write throttle alarm missing");
+            Assert.That(writeThrottle.Properties["MetricName"].Value<string>(), Is.EqualTo("WriteThrottleEvents"));
+            Assert.That(writeThrottle.Properties["Threshold"].Value<int>(), Is.EqualTo(defaultThrottleThreshold));
+            Assert.That(writeThrottle.Properties["Period"].Value<int>(), Is.EqualTo(60));
+            Assert.That(writeThrottle.Properties["ComparisonOperator"].Value<string>(),
+                Is.EqualTo("GreaterThanOrEqualToThreshold"));
+            Assert.That(writeThrottle.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
+            Assert.That(writeThrottle.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
         }
     }
 }

--- a/Watchman.Tests/IoCHelper.cs
+++ b/Watchman.Tests/IoCHelper.cs
@@ -25,7 +25,7 @@ namespace Watchman.Tests
             Func<WatchmanConfiguration, WatchmanServiceConfiguration<TAlarmConfig>> mapper,
             IAlarmCreator creator,
             IConfigLoader loader,
-            IResourceAlarmGenerator<TAlarmConfig> generator = null
+            IResourceAlarmGenerator<T, TAlarmConfig> generator = null
         )
             where T: class
             where TAlarmConfig : class, IServiceAlarmConfig<TAlarmConfig>, new()
@@ -104,7 +104,7 @@ namespace Watchman.Tests
             Func<WatchmanConfiguration, WatchmanServiceConfiguration<TAlarmConfig>> mapper)
             where TAlarmConfig : class, IServiceAlarmConfig<TAlarmConfig>, new()
         {
-            var generator = (IResourceAlarmGenerator<TAlarmConfig>) new DynamoResourceAlarmGenerator(
+            var generator = (IResourceAlarmGenerator<TableDescription, TAlarmConfig>) new DynamoResourceAlarmGenerator(
                 source,
                 dimensionProvider,
                 (IResourceAttributesProvider<TableDescription, ResourceConfig>) attributeProvider

--- a/Watchman.Tests/MultipleServiceAlarmTests.cs
+++ b/Watchman.Tests/MultipleServiceAlarmTests.cs
@@ -87,7 +87,7 @@ namespace Watchman.Tests
 
             var sutBuilder = new Builder(ConfigHelper.ConfigLoaderFor(config), creator);
 
-            sutBuilder.AddService(
+            sutBuilder.AddDynamoDbService(
                 new TableDescriptionSource(dynamoClient), 
                 new DynamoDbDataProvider(),
                 new DynamoDbDataProvider(),

--- a/Watchman/AwsServiceBootstrapper.cs
+++ b/Watchman/AwsServiceBootstrapper.cs
@@ -87,7 +87,7 @@ namespace Watchman
             where TDataProvider : IAlarmDimensionProvider<TServiceModel>,
             IResourceAttributesProvider<TServiceModel, TResourceAlarmConfig>
             where TResourceAlarmConfig : class, IServiceAlarmConfig<TResourceAlarmConfig>, new()
-            where TAlarmBuilder : IResourceAlarmGenerator<TResourceAlarmConfig>
+            where TAlarmBuilder : IResourceAlarmGenerator<TServiceModel, TResourceAlarmConfig>
         {
             registry.For<IResourceSource<TServiceModel>>().Use<TSource>();
             registry.For<IAlarmDimensionProvider<TServiceModel>>().Use<TDataProvider>();
@@ -98,7 +98,7 @@ namespace Watchman
                 .Ctor<Func<WatchmanConfiguration, WatchmanServiceConfiguration<TResourceAlarmConfig>>>()
                 .Is(mapper);
 
-            registry.For<IResourceAlarmGenerator<TResourceAlarmConfig>>().Use<TAlarmBuilder>();
+            registry.For<IResourceAlarmGenerator<TServiceModel, TResourceAlarmConfig>>().Use<TAlarmBuilder>();
         }
     }
 }


### PR DESCRIPTION
Finish support for dynamo tables and indexes via the newer approach. Currently completely separate from the older config so that we can trial it.

I need to do some more manual testing of the actual alarms before this gets merged