### PR TITLE
Update to current AWS packages

### DIFF
--- a/Quartermaster/Quartermaster.csproj
+++ b/Quartermaster/Quartermaster.csproj
@@ -4,9 +4,9 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="CsvHelper" Version="7.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />

--- a/TestHelper/TestHelper.csproj
+++ b/TestHelper/TestHelper.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
   </ItemGroup>
 </Project>

--- a/Watchman.AwsResources.IntegrationTests/Watchman.AwsResources.IntegrationTests.csproj
+++ b/Watchman.AwsResources.IntegrationTests/Watchman.AwsResources.IntegrationTests.csproj
@@ -3,13 +3,12 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.4" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.21" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
+    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.1" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12.1" />
+    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />

--- a/Watchman.AwsResources.IntegrationTests/Watchman.AwsResources.IntegrationTests.csproj
+++ b/Watchman.AwsResources.IntegrationTests/Watchman.AwsResources.IntegrationTests.csproj
@@ -3,12 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.1" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12.1" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />

--- a/Watchman.AwsResources.Tests/Watchman.AwsResources.Tests.csproj
+++ b/Watchman.AwsResources.Tests/Watchman.AwsResources.Tests.csproj
@@ -3,13 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.47.1" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.1" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12.1" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.1" />
     <PackageReference Include="Castle.Core" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.2" />

--- a/Watchman.AwsResources.Tests/Watchman.AwsResources.Tests.csproj
+++ b/Watchman.AwsResources.Tests/Watchman.AwsResources.Tests.csproj
@@ -3,14 +3,13 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.4" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.46" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.21" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.3.47.1" />
+    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.1" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12.1" />
+    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.1" />
     <PackageReference Include="Castle.Core" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.2" />

--- a/Watchman.AwsResources/Watchman.AwsResources.csproj
+++ b/Watchman.AwsResources/Watchman.AwsResources.csproj
@@ -3,15 +3,15 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.4" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.46" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.21" />
-    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2" />
+    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.4.1" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.3.47.1" />
+    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.1" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12.1" />
+    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.1" />
+    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Watchman.Configuration\Watchman.Configuration.csproj" />

--- a/Watchman.Engine.IntegrationTests/Watchman.Engine.IntegrationTests.csproj
+++ b/Watchman.Engine.IntegrationTests/Watchman.Engine.IntegrationTests.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.24" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.25" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />

--- a/Watchman.Engine.IntegrationTests/Watchman.Engine.IntegrationTests.csproj
+++ b/Watchman.Engine.IntegrationTests/Watchman.Engine.IntegrationTests.csproj
@@ -3,10 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.25" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />

--- a/Watchman.Engine.Tests/Watchman.Engine.Tests.csproj
+++ b/Watchman.Engine.Tests/Watchman.Engine.Tests.csproj
@@ -3,12 +3,12 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.17" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.24" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9.1" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.17.1" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.25" />
     <PackageReference Include="Castle.Core" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.2" />

--- a/Watchman.Engine.Tests/Watchman.Engine.Tests.csproj
+++ b/Watchman.Engine.Tests/Watchman.Engine.Tests.csproj
@@ -3,16 +3,9 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9.1" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.17.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.25" />
     <PackageReference Include="Castle.Core" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="StructureMap" Version="4.6.1" />

--- a/Watchman.Engine/Watchman.Engine.csproj
+++ b/Watchman.Engine/Watchman.Engine.csproj
@@ -3,12 +3,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.17" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.24" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9.1" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.17.1" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.25" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Watchman.Tests/Watchman.Tests.csproj
+++ b/Watchman.Tests/Watchman.Tests.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.24" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.25" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />

--- a/Watchman.Tests/Watchman.Tests.csproj
+++ b/Watchman.Tests/Watchman.Tests.csproj
@@ -3,13 +3,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.25" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="StructureMap" Version="4.6.1" />

--- a/Watchman/Watchman.csproj
+++ b/Watchman/Watchman.csproj
@@ -4,18 +4,17 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.4" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.14" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.46" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.21" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.17" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.24" />
-    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9.1" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.15" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.1" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.3.47.1" />
+    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.1" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12.1" />
+    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.17.1" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.25" />
+    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2.1" />
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="StructureMap" Version="4.6.1" />


### PR DESCRIPTION
Update to current AWS packages

Also removed a lot of refs to AWS packages in the tests. These are unnecessary, and having them there makes applying updates more of a pain. 

 [.Net core flows references through transitively between projects](https://www.erikheemskerk.nl/transitive-nuget-dependencies-net-core-got-your-back/) so we don't need to list them again. This is new behaviour in .NET core which we haven't been taking advantage of yet.


