### PR TITLE
Update the AWS SDK to latest packages

### DIFF
--- a/Quartermaster/Quartermaster.csproj
+++ b/Quartermaster/Quartermaster.csproj
@@ -4,9 +4,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.3" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.17" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.2" />
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="CsvHelper" Version="7.1.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />

--- a/TestHelper/TestHelper.csproj
+++ b/TestHelper/TestHelper.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.17" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.20" />
   </ItemGroup>
 </Project>

--- a/Watchman.AwsResources/Watchman.AwsResources.csproj
+++ b/Watchman.AwsResources/Watchman.AwsResources.csproj
@@ -3,15 +3,15 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.4.2" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.3" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.17" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.2" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.47.2" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12.2" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.4" />
-    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2.2" />
+    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.4.3" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.4" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.20" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.7.1" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.3.47.3" />
+    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.3" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.13" />
+    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.5" />
+    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Watchman.Configuration\Watchman.Configuration.csproj" />

--- a/Watchman.Engine/Watchman.Engine.csproj
+++ b/Watchman.Engine/Watchman.Engine.csproj
@@ -3,12 +3,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9.2" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.3" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.17" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.2" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.17.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.26" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.10" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.4" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.21.20" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.7.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.17.3" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.27" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Watchman/Watchman.csproj
+++ b/Watchman/Watchman.csproj
@@ -4,17 +4,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.9.2" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.5.3" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.21.17" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.6.2" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.47.2" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.2.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.12.2" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.21.4" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.17.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.26" />
-    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2.2" />
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="StructureMap" Version="4.6.1" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />


### PR DESCRIPTION
Update the AWS SDK to latest packages, as at April 2018 - it's all patch releases
Remove some AWS SDK refs that are not needed as they are already in upstream projects