### PR TITLE
Pull the "publish" step into the build script

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -13,3 +13,6 @@ DotNetTest "Quartermaster.Tests\Quartermaster.Tests.csproj"
 DotNetTest "Watchman.AwsResources.Tests\Watchman.AwsResources.Tests.csproj"
 DotNetTest "Watchman.Configuration.Tests\Watchman.Configuration.Tests.csproj"
 DotNetTest "Watchman.Engine.Tests\Watchman.Engine.Tests.csproj"
+
+Write-Host "Publishing artefacts..." -ForegroundColor Green
+& $dotnet publish -c Release AwsWatchman.sln


### PR DESCRIPTION
Can't be separate, but use the temporary $dotnet