### PR TITLE
Moving SQS over to service implementation

### DIFF
--- a/Watchman.AwsResources/Services/Sqs/QueueData.cs
+++ b/Watchman.AwsResources/Services/Sqs/QueueData.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Watchman.AwsResources.Services.Sqs
 {
     public class QueueData
     {
         public string Name { get; set; }
+
+        public bool IsErrorQueue { get; set; }
     }
 }

--- a/Watchman.AwsResources/Services/Sqs/QueueDataProvider.cs
+++ b/Watchman.AwsResources/Services/Sqs/QueueDataProvider.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudWatch.Model;
+using Amazon.Lambda.Model;
+using Watchman.Configuration.Generic;
+
+namespace Watchman.AwsResources.Services.Sqs
+{
+    public class QueueDataProvider : IAlarmDimensionProvider<QueueData>, IResourceAttributesProvider<QueueData, SqsResourceConfig>
+    {
+        public List<Dimension> GetDimensions(QueueData resource, IList<string> dimensionNames)
+        {
+            var allowed = new List<Dimension>()
+                          {
+                              new Dimension()
+                              {
+                                  Name = "QueueName",
+                                  Value = resource.Name
+                              }
+                          };
+
+            var requested = dimensionNames
+                .Join(allowed, name => name, dim => dim.Name, (_, dim) => dim)
+                .ToList();
+
+            if (requested.Count != dimensionNames.Count)
+            {
+                var missing = dimensionNames
+                    .Except(requested.Select(dim => dim.Name))
+                    .ToArray();
+
+                throw new Exception($"Requested dimension names are not valid: {string.Join(",", missing)}");
+            }
+
+            return requested;
+        }
+
+        public Task<decimal> GetValue(QueueData resource, SqsResourceConfig config, string property)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Watchman.AwsResources/Services/Sqs/QueueSource.cs
+++ b/Watchman.AwsResources/Services/Sqs/QueueSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -76,7 +76,7 @@ namespace Watchman.AwsResources.Services.Sqs
         {
             var names = await ReadActiveQueueNames();
 
-            return names.Select(n => new QueueData() {Name = n}).ToList();
+            return names.Select(n => new QueueData() {Name = n, IsErrorQueue = n.EndsWith("_error")}).ToList();
         }
     }
 }

--- a/Watchman.Configuration/AlertingGroupServices.cs
+++ b/Watchman.Configuration/AlertingGroupServices.cs
@@ -14,9 +14,11 @@ namespace Watchman.Configuration
         public AwsServiceAlarms<ResourceConfig> KinesisStream { get; set; }
         public AwsServiceAlarms<ResourceConfig> StepFunction { get; set; }
         public AwsServiceAlarms<ResourceConfig> DynamoDb { get; set; }
+        public AwsServiceAlarms<SqsResourceConfig> Sqs { get; set; }
+
 
         public IList<IAwsServiceAlarms> AllServices => new IAwsServiceAlarms[]
-            { Rds, AutoScaling, Lambda, VpcSubnet, Elb, KinesisStream, StepFunction, DynamoDb }
+            { Rds, AutoScaling, Lambda, VpcSubnet, Elb, KinesisStream, StepFunction, DynamoDb, Sqs }
             .Where(s => s != null)
             .ToArray();
 
@@ -29,7 +31,8 @@ namespace Watchman.Configuration
             {"Elb", Elb},
             {"KinesisStream", KinesisStream},
             {"StepFunction", StepFunction},
-            {"DynamoDb", DynamoDb}
+            {"DynamoDb", DynamoDb},
+            {"Sqs", Sqs }
         };
     }
 }

--- a/Watchman.Configuration/Generic/SqsResourceConfig.cs
+++ b/Watchman.Configuration/Generic/SqsResourceConfig.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Watchman.Configuration.Generic
+{
+    public class SqsResourceConfig : IServiceAlarmConfig<SqsResourceConfig>
+    {
+        public bool? IncludeErrorQueues { get; set; }
+
+        public SqsResourceConfig Merge(SqsResourceConfig parentConfig)
+        {
+            if (parentConfig == null)
+            {
+                throw new ArgumentNullException(nameof(parentConfig));
+            }
+
+            return new SqsResourceConfig()
+                   {
+                       IncludeErrorQueues = IncludeErrorQueues ?? parentConfig.IncludeErrorQueues
+                   };
+        }
+    }
+
+}

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -505,5 +505,77 @@ namespace Watchman.Engine.Alarms
                 Namespace = AwsNamespace.DynamoDb
             }
         };
+
+        public static IList<AlarmDefinition> Sqs = new List<AlarmDefinition>
+        {
+            new AlarmDefinition
+            {
+                Name = "NumberOfVisibleMessages",
+                Metric = "ApproximateNumberOfMessagesVisible",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.QueueLengthThreshold
+                },
+                DimensionNames = new[] {"QueueName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.Sqs
+            },
+            new AlarmDefinition
+            {
+                Name = "AgeOfOldestMessage",
+                Metric = "ApproximateAgeOfOldestMessage",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                            {
+                                ThresholdType = ThresholdType.Absolute,
+                                Value = AwsConstants.OldestMessageThreshold
+                            },
+                DimensionNames = new[] {"QueueName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Maximum,
+                Namespace = AwsNamespace.Sqs
+            }
+        };
+
+        public static IList<AlarmDefinition> SqsError = new List<AlarmDefinition>
+        {
+            new AlarmDefinition
+            {
+                Name = "NumberOfVisibleMessages_Error",
+                Metric = "ApproximateNumberOfMessagesVisible",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.ErrorQueueLengthThreshold
+                },
+                DimensionNames = new[] {"QueueName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.Sqs
+            },
+            new AlarmDefinition
+            {
+                Name = "AgeOfOldestMessage_Error",
+                Metric = "ApproximateAgeOfOldestMessage",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                            {
+                                ThresholdType = ThresholdType.Absolute,
+                                Value = AwsConstants.OldestMessageThreshold
+                            },
+                DimensionNames = new[] {"QueueName"},
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Maximum,
+                Namespace = AwsNamespace.Sqs
+            }
+        };
     }
 }

--- a/Watchman.Engine/Generation/Sqs/SqsResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Sqs/SqsResourceAlarmGenerator.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.Model;
+using Watchman.AwsResources;
+using Watchman.AwsResources.Services.Sqs;
+using Watchman.Configuration.Generic;
+using Watchman.Engine.Alarms;
+
+namespace Watchman.Engine.Generation.Sqs
+{
+    public class SqsResourceAlarmGenerator : IResourceAlarmGenerator<QueueData, SqsResourceConfig>
+    {
+        private readonly AlarmBuilder<QueueData, SqsResourceConfig> _builder;
+        private readonly IResourceSource<QueueData> _queueSource;
+        private readonly IAlarmDimensionProvider<QueueData> _dimensionProvider;
+        private readonly IList<AlarmDefinition> _errorQueueDefaults = Defaults.SqsError;
+
+        public SqsResourceAlarmGenerator(
+            IResourceSource<QueueData> queueSource,
+            IAlarmDimensionProvider<QueueData> dimensionProvider,
+            IResourceAttributesProvider<QueueData, SqsResourceConfig> attributeProvider)
+        {
+            _builder = new AlarmBuilder<QueueData, SqsResourceConfig>(attributeProvider);
+            _queueSource = queueSource;
+            _dimensionProvider = dimensionProvider;
+        }
+
+        public async Task<IList<Alarm>> GenerateAlarmsFor(
+            AwsServiceAlarms<SqsResourceConfig> service,
+            IList<AlarmDefinition> defaults,
+            AlertingGroupParameters groupParameters)
+        {
+            if (service?.Resources == null || service.Resources.Count == 0)
+            {
+                return new List<Alarm>();
+            }
+
+            List<Alarm> alarms = new List<Alarm>();
+
+            foreach (var resource in service.Resources)
+            {
+               var alarmsForResource = await CreateAlarmsForResource(
+                    resource?.Options?.IncludeErrorQueues ?? true,
+                    defaults,
+                    resource,
+                    service,
+                    groupParameters);
+                alarms.AddRange(alarmsForResource);
+            }
+
+            return alarms;
+        }
+
+        private async Task<IList<Alarm>> CreateAlarmsForResource(
+            bool includeErrorQueues,
+            IList<AlarmDefinition> defaults,
+            ResourceThresholds<SqsResourceConfig> resource,
+            AwsServiceAlarms<SqsResourceConfig> service,
+            AlertingGroupParameters groupParameters)
+        {
+            var entity = await _queueSource.GetResourceAsync(resource.Name);
+
+            if (entity == null)
+            {
+                throw new Exception($"Entity {resource.Name} not found");
+            }
+
+            var isErrorQueue = entity.Resource.IsErrorQueue;
+
+            if (isErrorQueue && !includeErrorQueues)
+            {
+                return new List<Alarm>();
+            }
+
+            var defaultsInput = isErrorQueue ? _errorQueueDefaults : defaults;
+            return await BuildAlarms(defaultsInput, resource, service, groupParameters, entity);
+        }
+
+        private async Task<List<Alarm>> BuildAlarms(
+            IList<AlarmDefinition> defaults,
+            ResourceThresholds<SqsResourceConfig> resource,
+            AwsServiceAlarms<SqsResourceConfig> service,
+            AlertingGroupParameters groupParameters,
+            AwsResource<QueueData> entity)
+        {
+            var expanded = await _builder.CopyAndUpdateDefaultAlarmsForResource(entity, defaults, service, resource);
+
+            var result = new List<Alarm>();
+
+            foreach (var alarm in expanded)
+            {
+                var dimensions = _dimensionProvider.GetDimensions(entity.Resource, alarm.DimensionNames);
+
+                var model = new Alarm
+                            {
+                                AlarmName = $"{resource.Name}-{alarm.Name}-{groupParameters.AlarmNameSuffix}",
+                                AlarmDescription = _builder.GetAlarmDescription(groupParameters),
+                                Resource = entity,
+                                Dimensions = dimensions,
+                                AlarmDefinition = alarm
+                            };
+                result.Add(model);
+            }
+            return result;
+        }
+    }
+}

--- a/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
+++ b/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
@@ -58,6 +58,13 @@ namespace Watchman.Engine.Generation
             return Map(input, id, a => a?.Services?.DynamoDb, Defaults.DynamoDb);
         }
 
+        public static WatchmanServiceConfiguration<SqsResourceConfig> MapSqs(WatchmanConfiguration input)
+        {
+            const string id = "Sqs";
+            return Map(input, id, a => a?.Services?.Sqs, Defaults.Sqs);
+        }
+
+
         private static WatchmanServiceConfiguration<TConfig> Map<TConfig>(WatchmanConfiguration input,
             string serviceName,
             Func<AlertingGroup, AwsServiceAlarms<TConfig>> readServiceFromGroup,

--- a/Watchman.Tests/Fakes/FakeAwsClients.cs
+++ b/Watchman.Tests/Fakes/FakeAwsClients.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Threading;
 using Amazon.AutoScaling;
 using Amazon.AutoScaling.Model;
+using Amazon.CloudWatch;
+using Amazon.CloudWatch.Model;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.ElasticLoadBalancing;
@@ -59,6 +61,30 @@ namespace Watchman.Tests.Fakes
                     });
 
             }
+        }
+
+        public static void HasSqsQueues(this Mock<IAmazonCloudWatch> fake, IEnumerable<string> queues)
+        {
+            fake
+                .Setup(x => x.ListMetricsAsync(It.IsAny<ListMetricsRequest>(), new CancellationToken()))
+                .ReturnsAsync(new ListMetricsResponse()
+                              {
+                                  Metrics = queues.Select(q => new Metric()
+                                                               {
+                                                                   MetricName = "ApproximateAgeOfOldestMessage",
+                                                                   Dimensions =
+                                                                       new List<Amazon.CloudWatch.Model.Dimension
+                                                                       >()
+                                                                       {
+                                                                           new Amazon.CloudWatch.Model.Dimension()
+                                                                           {
+                                                                               Name = "QueueName",
+                                                                               Value = q
+                                                                           }
+                                                                       }
+                                                               }).ToList()
+                              });
+
         }
 
         public static void HasLambdaFunctions(this Mock<IAmazonLambda> fake, IEnumerable<FunctionConfiguration> functions)

--- a/Watchman.Tests/Sqs/SqsAlarmTests.cs
+++ b/Watchman.Tests/Sqs/SqsAlarmTests.cs
@@ -1,0 +1,337 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.CloudWatch;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Watchman.Configuration;
+using Watchman.Configuration.Generic;
+using Watchman.Engine;
+using Watchman.Engine.Generation;
+using Watchman.Tests.Fakes;
+using Watchman.Tests.IoC;
+
+namespace Watchman.Tests.Sqs
+{
+    public class SqsAlarmTests
+    {
+        [Test]
+        public async Task IgnoresNamedEntitiesThatDoNotExist()
+        {
+            // arrange
+            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix",
+                new AlertingGroupServices()
+                {
+                    Sqs = new AwsServiceAlarms<SqsResourceConfig>()
+                               {
+                                   Resources = new List<ResourceThresholds<SqsResourceConfig>>()
+                                               {
+                                                   new ResourceThresholds<SqsResourceConfig>()
+                                                   {
+                                                       Name = "non-existent-queue"
+                                                   }
+                                               }
+                               }
+                });
+
+            var cloudformation = new FakeCloudFormation();
+            var ioc = new TestingIocBootstrapper()
+                .WithCloudFormation(cloudformation.Instance)
+                .WithConfig(config);
+
+            ioc.GetMock<IAmazonCloudWatch>().HasSqsQueues(new[]
+                                                   {
+                                                       "http://sqs.com/first-queue"
+                                                   });
+
+            var sut = ioc.Get<AlarmLoaderAndGenerator>();
+
+            // act
+
+            await sut.LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            // assert
+            Assert.That(cloudformation.StacksDeployed, Is.Zero);
+        }
+
+        [Test]
+        public async Task AlarmCreatedWithCorrectProperties()
+        {
+            // arrange
+            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix", new AlertingGroupServices()
+            {
+                Sqs = new AwsServiceAlarms<SqsResourceConfig>()
+                {
+                    Resources = new List<ResourceThresholds<SqsResourceConfig>>()
+                    {
+                        new ResourceThresholds<SqsResourceConfig>()
+                        {
+                            Pattern = "first-sqs-queue"
+                        }
+                    }
+                }
+            });
+
+            var cloudformation = new FakeCloudFormation();
+            var ioc = new TestingIocBootstrapper()
+                .WithCloudFormation(cloudformation.Instance)
+                .WithConfig(config);
+
+            ioc.GetMock<IAmazonCloudWatch>().HasSqsQueues(new[]
+            {
+                "first-sqs-queue",
+                "first-sqs-queue_error"
+            });
+
+            var sut = ioc.Get<AlarmLoaderAndGenerator>();
+
+            // act
+
+            await sut.LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            // assert
+            
+            var alarmsByQueue = cloudformation
+                .Stack("Watchman-test")
+                .AlarmsByDimension("QueueName");
+
+            Assert.That(alarmsByQueue.ContainsKey("first-sqs-queue"), Is.True);
+            var alarmsForQueue = alarmsByQueue["first-sqs-queue"];
+
+            Assert.That(alarmsForQueue.Exists(
+                alarm =>
+                    alarm.Properties["MetricName"].Value<string>() == "ApproximateNumberOfMessagesVisible"
+                    && alarm.Properties["AlarmName"].Value<string>().Contains("NumberOfVisibleMessages")
+                    && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                    && alarm.Properties["Threshold"].Value<int>() == 100
+                    && alarm.Properties["Period"].Value<int>() == 60
+                    && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                    && alarm.Properties["Statistic"].Value<string>() == "Sum"
+                    && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                    )
+                );
+
+            Assert.That(alarmsForQueue.Exists(
+                    alarm =>
+                        alarm.Properties["MetricName"].Value<string>() == "ApproximateAgeOfOldestMessage"
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("AgeOfOldestMessage")
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                        && alarm.Properties["Threshold"].Value<int>() == 600
+                        && alarm.Properties["Period"].Value<int>() == 60
+                        && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                        && alarm.Properties["Statistic"].Value<string>() == "Maximum"
+                        && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                )
+            );
+
+            var alarmsForErrorQueue = alarmsByQueue["first-sqs-queue_error"];
+
+            Assert.That(alarmsForErrorQueue.Exists(
+                    alarm =>
+                        alarm.Properties["MetricName"].Value<string>() == "ApproximateNumberOfMessagesVisible"
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("NumberOfVisibleMessages_Error")
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                        && alarm.Properties["Threshold"].Value<int>() == 10
+                        && alarm.Properties["Period"].Value<int>() == 60
+                        && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                        && alarm.Properties["Statistic"].Value<string>() == "Sum"
+                        && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                )
+            );
+
+            Assert.That(alarmsForErrorQueue.Exists(
+                    alarm =>
+                        alarm.Properties["MetricName"].Value<string>() == "ApproximateAgeOfOldestMessage"
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("AgeOfOldestMessage_Error")
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                        && alarm.Properties["Threshold"].Value<int>() == 600
+                        && alarm.Properties["Period"].Value<int>() == 60
+                        && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                        && alarm.Properties["Statistic"].Value<string>() == "Maximum"
+                        && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                )
+            );
+        }
+
+
+        [Test]
+        public async Task AlarmWithIncludeErrorQueuesFalseWillNotCreateErrorQueueAlarms()
+        {
+            // arrange
+            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix", new AlertingGroupServices()
+            {
+                Sqs = new AwsServiceAlarms<SqsResourceConfig>()
+                {
+                    Resources = new List<ResourceThresholds<SqsResourceConfig>>()
+                    {
+                        new ResourceThresholds<SqsResourceConfig>()
+                        {
+                            Pattern = "first-sqs-queue",
+                            Options = new SqsResourceConfig()
+                                      {
+                                          IncludeErrorQueues = false
+                                      },
+                        }
+                    }
+                }
+            });
+
+            var cloudformation = new FakeCloudFormation();
+            var ioc = new TestingIocBootstrapper()
+                .WithCloudFormation(cloudformation.Instance)
+                .WithConfig(config);
+
+            ioc.GetMock<IAmazonCloudWatch>().HasSqsQueues(new[]
+            {
+                "first-sqs-queue",
+                "first-sqs-queue_error"
+            });
+
+            var sut = ioc.Get<AlarmLoaderAndGenerator>();
+
+            // act
+
+            await sut.LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            // assert
+
+            var alarmsByQueue = cloudformation
+                .Stack("Watchman-test")
+                .AlarmsByDimension("QueueName");
+
+            Assert.That(alarmsByQueue.ContainsKey("first-sqs-queue"), Is.True);
+            var alarmsForQueue = alarmsByQueue["first-sqs-queue"];
+
+            Assert.That(alarmsForQueue.Exists(
+                alarm =>
+                    alarm.Properties["MetricName"].Value<string>() == "ApproximateNumberOfMessagesVisible"
+                    && alarm.Properties["AlarmName"].Value<string>().Contains("NumberOfVisibleMessages")
+                    && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                    && alarm.Properties["Threshold"].Value<int>() == 100
+                    && alarm.Properties["Period"].Value<int>() == 60
+                    && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                    && alarm.Properties["Statistic"].Value<string>() == "Sum"
+                    && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                    )
+                );
+
+            Assert.That(alarmsForQueue.Exists(
+                    alarm =>
+                        alarm.Properties["MetricName"].Value<string>() == "ApproximateAgeOfOldestMessage"
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("AgeOfOldestMessage")
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                        && alarm.Properties["Threshold"].Value<int>() == 600
+                        && alarm.Properties["Period"].Value<int>() == 60
+                        && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                        && alarm.Properties["Statistic"].Value<string>() == "Maximum"
+                        && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                )
+            );
+
+            Assert.That(!alarmsByQueue.ContainsKey("first-sqs-queue_error"));
+        }
+
+
+        [Test]
+        public async Task AlarmWithManuallySetThresholdRetainsThatValueForTheRelevantAlarm()
+        {
+            // arrange
+            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix", new AlertingGroupServices()
+            {
+                Sqs = new AwsServiceAlarms<SqsResourceConfig>()
+                {
+                    Resources = new List<ResourceThresholds<SqsResourceConfig>>()
+                    {
+                        new ResourceThresholds<SqsResourceConfig>()
+                        {
+                            Pattern = "first-sqs-queue",
+                            Values = new Dictionary<string, AlarmValues>()
+                                     {
+                                         { "NumberOfVisibleMessages_Error", new AlarmValues(value: 1) }
+                                     }
+                        }
+                    }
+                }
+            });
+
+            var cloudformation = new FakeCloudFormation();
+            var ioc = new TestingIocBootstrapper()
+                .WithCloudFormation(cloudformation.Instance)
+                .WithConfig(config);
+
+            ioc.GetMock<IAmazonCloudWatch>().HasSqsQueues(new[]
+            {
+                "first-sqs-queue",
+                "first-sqs-queue_error"
+            });
+
+            var sut = ioc.Get<AlarmLoaderAndGenerator>();
+
+            // act
+
+            await sut.LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            // assert
+
+            var alarmsByQueue = cloudformation
+                .Stack("Watchman-test")
+                .AlarmsByDimension("QueueName");
+
+            Assert.That(alarmsByQueue.ContainsKey("first-sqs-queue"), Is.True);
+            var alarmsForQueue = alarmsByQueue["first-sqs-queue"];
+
+            Assert.That(alarmsForQueue.Exists(
+                alarm =>
+                    alarm.Properties["MetricName"].Value<string>() == "ApproximateNumberOfMessagesVisible"
+                    && alarm.Properties["AlarmName"].Value<string>().Contains("NumberOfVisibleMessages")
+                    && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                    && alarm.Properties["Threshold"].Value<int>() == 100
+                    && alarm.Properties["Period"].Value<int>() == 60
+                    && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                    && alarm.Properties["Statistic"].Value<string>() == "Sum"
+                    && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                    )
+                );
+
+            Assert.That(alarmsForQueue.Exists(
+                    alarm =>
+                        alarm.Properties["MetricName"].Value<string>() == "ApproximateAgeOfOldestMessage"
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("AgeOfOldestMessage")
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                        && alarm.Properties["Threshold"].Value<int>() == 600
+                        && alarm.Properties["Period"].Value<int>() == 60
+                        && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                        && alarm.Properties["Statistic"].Value<string>() == "Maximum"
+                        && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                )
+            );
+
+            var alarmsForErrorQueue = alarmsByQueue["first-sqs-queue_error"];
+
+            Assert.That(alarmsForErrorQueue.Exists(
+                    alarm =>
+                        alarm.Properties["MetricName"].Value<string>() == "ApproximateNumberOfMessagesVisible"
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("NumberOfVisibleMessages_Error")
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                        && alarm.Properties["Threshold"].Value<int>() == 1
+                        && alarm.Properties["Period"].Value<int>() == 60
+                        && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                        && alarm.Properties["Statistic"].Value<string>() == "Sum"
+                        && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                )
+            );
+
+            Assert.That(alarmsForErrorQueue.Exists(
+                    alarm =>
+                        alarm.Properties["MetricName"].Value<string>() == "ApproximateAgeOfOldestMessage"
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("AgeOfOldestMessage_Error")
+                        && alarm.Properties["AlarmName"].Value<string>().Contains("-group-suffix")
+                        && alarm.Properties["Threshold"].Value<int>() == 600
+                        && alarm.Properties["Period"].Value<int>() == 60
+                        && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
+                        && alarm.Properties["Statistic"].Value<string>() == "Maximum"
+                        && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                )
+            );
+        }
+    }
+}

--- a/Watchman/IoC/AwsServiceRegistry.cs
+++ b/Watchman/IoC/AwsServiceRegistry.cs
@@ -13,6 +13,7 @@ using Watchman.AwsResources.Services.Elb;
 using Watchman.AwsResources.Services.Kinesis;
 using Watchman.AwsResources.Services.Lambda;
 using Watchman.AwsResources.Services.Rds;
+using Watchman.AwsResources.Services.Sqs;
 using Watchman.AwsResources.Services.StepFunction;
 using Watchman.AwsResources.Services.VpcSubnet;
 using Watchman.Configuration;
@@ -20,6 +21,7 @@ using Watchman.Configuration.Generic;
 using Watchman.Engine;
 using Watchman.Engine.Generation;
 using Watchman.Engine.Generation.Dynamo;
+using Watchman.Engine.Generation.Sqs;
 using Subnet = Amazon.EC2.Model.Subnet;
 
 namespace Watchman.IoC
@@ -60,6 +62,9 @@ namespace Watchman.IoC
             
             AddService<TableDescription, TableDescriptionSource, DynamoDbDataProvider, ResourceConfig, DynamoResourceAlarmGenerator>(
                 WatchmanServiceConfigurationMapper.MapDynamoDb);
+
+            AddService<QueueData, QueueSource, QueueDataProvider, SqsResourceConfig, SqsResourceAlarmGenerator>(
+                WatchmanServiceConfigurationMapper.MapSqs);
         }
 
         private void AddService<TServiceModel, TSource, TDataProvider, TResourceAlarmConfig>(

--- a/Watchman/IoC/BoundaryRegistry.cs
+++ b/Watchman/IoC/BoundaryRegistry.cs
@@ -1,4 +1,3 @@
-using Amazon;
 using Amazon.AutoScaling;
 using Amazon.CloudFormation;
 using Amazon.CloudWatch;
@@ -7,7 +6,6 @@ using Amazon.EC2;
 using Amazon.ElasticLoadBalancing;
 using Amazon.Lambda;
 using Amazon.RDS;
-using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.SimpleNotificationService;
 using Amazon.StepFunctions;


### PR DESCRIPTION
As discussed with @tomhaigh previously, I wanted to use the number of datapoints feature for SQS alarms, but because it was stuck on a older implementation it wasn't possible. I have ported it over and left the previous implementation intact so that it won't be a breaking change.

- I have had to create a slightly hacky implementation of the `AlarmGenerator` to cater for the fact that SQS has to set alarms on queues and error queues with different defaults. It doesn't quite fit into the abstraction and the workaround isn't ideal, but was the best I could manage.
