### PR TITLE
Added invocations low alarm for lambdas

### DIFF
--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -142,7 +142,17 @@ For each resource each of the default alarms will be applied. See [alarm definit
 - `ErrorsHigh`: 3 (count)
 - `DurationHigh`: 50 (% of defined Timeout)
 - `ThrottlesHigh`: 5 (count)
-- `InvocationsLow`: Disabled by default. If enabled it checks the function was executed at least once in the day.
+- `InvocationsLow`: Disabled by default. If enabled it checks the function was executed at least once in a day. To enable it and/or change the defaults
+```json
+      "Values": {
+		"InvocationsLow": {
+			"Enabled": true,
+			"Threshold": 2,
+			"EvaluationPeriods": 140
+		}
+      }
+```
+The above will enable the alert and check the function was executed at least twice in a day.
 
 ### Kinesis
 

--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -142,17 +142,7 @@ For each resource each of the default alarms will be applied. See [alarm definit
 - `ErrorsHigh`: 3 (count)
 - `DurationHigh`: 50 (% of defined Timeout)
 - `ThrottlesHigh`: 5 (count)
-- `InvocationsLow`: Disabled by default. If enabled it checks the function was executed at least once in a day. To enable it and/or change the defaults
-```json
-      "Values": {
-		"InvocationsLow": {
-			"Enabled": true,
-			"Threshold": 2,
-			"EvaluationPeriods": 140
-		}
-      }
-```
-The above will enable the alert and check the function was executed at least twice in a day.
+- `InvocationsLow`: Disabled by default. If enabled it checks the function was executed at least once in a day.
 
 ### Kinesis
 

--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -142,6 +142,7 @@ For each resource each of the default alarms will be applied. See [alarm definit
 - `ErrorsHigh`: 3 (count)
 - `DurationHigh`: 50 (% of defined Timeout)
 - `ThrottlesHigh`: 5 (count)
+- `InvocationsLow`: Disabled by default. If enabled it checks the function was executed at least once in the day.
 
 ### Kinesis
 

--- a/Watchman.Configuration.Tests/Load/ConfigFileLoaderThresholdTests.cs
+++ b/Watchman.Configuration.Tests/Load/ConfigFileLoaderThresholdTests.cs
@@ -97,12 +97,13 @@ namespace Watchman.Configuration.Tests.Load
 
             Assert.That(section.Values, Is.Not.Null);
             Assert.That(section.Values, Is.Not.Empty);
-            Assert.That(section.Values.Count, Is.EqualTo(7));
+            Assert.That(section.Values.Count, Is.EqualTo(8));
 
             Assert.That(section.Values["ThrottlesHigh"].Threshold, Is.EqualTo(40));
             Assert.That(section.Values["FloatValue"].Threshold, Is.EqualTo(2.1));
             Assert.That(section.Values["FloatValueAsString"].Threshold, Is.EqualTo(2.2));
             Assert.That(section.Values["IntValueAsString"].Threshold, Is.EqualTo(41));
+            Assert.That(section.Values["InvocationsLow"].Threshold, Is.EqualTo(5));
         }
 
         [Test]
@@ -116,6 +117,7 @@ namespace Watchman.Configuration.Tests.Load
             var errrorsHigh = values["ErrorsHigh"];
             var durationHigh = values["DurationHigh"];
             var throttlesHigh = values["ThrottlesHigh"];
+            var invocationsLow = values["InvocationsLow"];
             var fooHigh = values["FooHigh"];
 
             Assert.That(errrorsHigh.Threshold, Is.EqualTo(20));
@@ -129,6 +131,9 @@ namespace Watchman.Configuration.Tests.Load
 
             Assert.That(fooHigh.Threshold, Is.Null);
             Assert.That(fooHigh.EvaluationPeriods, Is.EqualTo(3));
+
+            Assert.That(invocationsLow.Threshold, Is.EqualTo(5));
+            Assert.That(invocationsLow.EvaluationPeriods, Is.Null);
         }
     }
 }

--- a/Watchman.Configuration.Tests/data/withThresholds/Lambda.json
+++ b/Watchman.Configuration.Tests/data/withThresholds/Lambda.json
@@ -26,7 +26,8 @@
         "ThrottlesHigh": 40,
         "FloatValue": 2.1,
         "FloatValueAsString": "2.2",
-        "IntValueAsString": "41"
+        "IntValueAsString": "41",
+        "InvocationsLow": 5
       }
     }
   }

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -183,6 +183,23 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Lambda
+            },
+            new AlarmDefinition
+            {
+                Name = "InvocationsLow",
+                Enabled = false,
+                Metric = "Invocations",
+                Period = TimeSpan.FromMinutes(5),
+                EvaluationPeriods = 288,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = 1
+                },
+                DimensionNames = new[] {"FunctionName"},
+                ComparisonOperator = ComparisonOperator.LessThanThreshold,
+                Statistic = Statistic.SampleCount,
+                Namespace = AwsNamespace.Lambda
             }
         };
 


### PR DESCRIPTION
You can use this alarm in case it is important that your lambda function is executed at least once in a day. By default is disabled, because probably not all the lambdas would need such an alert, but there are cases that it would be useful to be alerted if the lambda has not run at all.