### PR TITLE
Updating the default for SQS alarms to use a period of 5 minutes

### DIFF
--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -529,7 +529,7 @@ namespace Watchman.Engine.Alarms
             {
                 Name = "NumberOfVisibleMessages",
                 Metric = "ApproximateNumberOfMessagesVisible",
-                Period = TimeSpan.FromMinutes(1),
+                Period = TimeSpan.FromMinutes(5),
                 EvaluationPeriods = 1,
                 Threshold = new Threshold
                 {
@@ -545,7 +545,7 @@ namespace Watchman.Engine.Alarms
             {
                 Name = "AgeOfOldestMessage",
                 Metric = "ApproximateAgeOfOldestMessage",
-                Period = TimeSpan.FromMinutes(1),
+                Period = TimeSpan.FromMinutes(5),
                 EvaluationPeriods = 1,
                 Threshold = new Threshold
                             {
@@ -565,7 +565,7 @@ namespace Watchman.Engine.Alarms
             {
                 Name = "NumberOfVisibleMessages_Error",
                 Metric = "ApproximateNumberOfMessagesVisible",
-                Period = TimeSpan.FromMinutes(1),
+                Period = TimeSpan.FromMinutes(5),
                 EvaluationPeriods = 1,
                 Threshold = new Threshold
                 {
@@ -581,7 +581,7 @@ namespace Watchman.Engine.Alarms
             {
                 Name = "AgeOfOldestMessage_Error",
                 Metric = "ApproximateAgeOfOldestMessage",
-                Period = TimeSpan.FromMinutes(1),
+                Period = TimeSpan.FromMinutes(5),
                 EvaluationPeriods = 1,
                 Threshold = new Threshold
                             {


### PR DESCRIPTION
After doing some digging, it turns out that SQS doesn't provide detailed metrics so the lowest time period that we can look at is 5 minutes, and they recommend not looking at anything less than that as may return incorrect data.