### PR TITLE
Fix some issues

### DIFF
--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -397,7 +397,7 @@ namespace Watchman.Engine.Alarms
                     Value = AwsConstants.DefaultCapacityThreshold * 100,
                     SourceAttribute = "ProvisionedReadThroughput"
                 },
-                DimensionNames = new[] {"GlobalSecondaryIndexName"},
+                DimensionNames = new[] {"GlobalSecondaryIndexName", "TableName"},
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb
@@ -414,7 +414,7 @@ namespace Watchman.Engine.Alarms
                     Value = AwsConstants.DefaultCapacityThreshold * 100,
                     SourceAttribute = "ProvisionedWriteThroughput"
                 },
-                DimensionNames = new[] {"GlobalSecondaryIndexName"},
+                DimensionNames = new[] {"GlobalSecondaryIndexName", "TableName"},
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb
@@ -430,7 +430,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = AwsConstants.ThrottlingThreshold
                 },
-                DimensionNames = new[] {"GlobalSecondaryIndexName"},
+                DimensionNames = new[] {"GlobalSecondaryIndexName", "TableName"},
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb
@@ -446,7 +446,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = AwsConstants.ThrottlingThreshold
                 },
-                DimensionNames = new[] {"GlobalSecondaryIndexName"},
+                DimensionNames = new[] {"GlobalSecondaryIndexName", "TableName"},
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb

--- a/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
@@ -133,7 +133,7 @@ namespace Watchman.Engine.Generation.Dynamo
                 {
                     var values = mergedValuesByAlarmName.GetValueOrDefault(alarm.Name) ?? new AlarmValues();
                     var configuredThreshold = alarm.Threshold.CopyWith(value: values.Threshold);
-                    var dimensions = _gsiProvider.GetDimensions(gsi, alarm.DimensionNames);
+                    var dimensions = _gsiProvider.GetDimensions(gsi, parentTableEntity.Resource, alarm.DimensionNames);
                     var threshold = await ThresholdCalculator.ExpandThreshold(_gsiProvider,
                         gsiResource.Resource,
                         mergedConfig,

--- a/Watchman.Tests/Dynamo/DynamoAlarmTests.cs
+++ b/Watchman.Tests/Dynamo/DynamoAlarmTests.cs
@@ -263,6 +263,7 @@ namespace Watchman.Tests.Dynamo
                 Is.EqualTo("GreaterThanOrEqualToThreshold"));
             Assert.That(consumedRead.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(consumedRead.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+            Assert.That(consumedRead.Dimension("TableName"), Is.EqualTo("first-table"));
 
             var consumedWrite = alarms.SingleOrDefault(
                 a => a.Properties["AlarmName"].ToString()
@@ -277,6 +278,7 @@ namespace Watchman.Tests.Dynamo
                 Is.EqualTo("GreaterThanOrEqualToThreshold"));
             Assert.That(consumedWrite.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(consumedWrite.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+            Assert.That(consumedWrite.Dimension("TableName"), Is.EqualTo("first-table"));
 
             var readThrottle = alarms.SingleOrDefault(
                 a => a.Properties["AlarmName"].ToString()
@@ -289,6 +291,7 @@ namespace Watchman.Tests.Dynamo
                 Is.EqualTo("GreaterThanOrEqualToThreshold"));
             Assert.That(readThrottle.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(readThrottle.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+            Assert.That(readThrottle.Dimension("TableName"), Is.EqualTo("first-table"));
 
             var writeThrottle = alarms.SingleOrDefault(
                 a => a.Properties["AlarmName"].ToString()
@@ -301,6 +304,7 @@ namespace Watchman.Tests.Dynamo
                 Is.EqualTo("GreaterThanOrEqualToThreshold"));
             Assert.That(writeThrottle.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(writeThrottle.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+            Assert.That(writeThrottle.Dimension("TableName"), Is.EqualTo("first-table"));
         }
 
 
@@ -317,12 +321,12 @@ namespace Watchman.Tests.Dynamo
                         {
                             new ResourceThresholds<ResourceConfig>()
                             {
-                                Name = "first-table",
-                                 Values = new Dictionary<string, AlarmValues>()
-                                 {
+                                Pattern = "first-table",
+                                Values = new Dictionary<string, AlarmValues>()
+                                {
                                     {"GsiConsumedReadCapacityUnitsHigh", 20},
                                     {"ConsumedReadCapacityUnitsHigh", 10}
-                                 }
+                                }
                             }
                         }
                 }
@@ -337,7 +341,7 @@ namespace Watchman.Tests.Dynamo
             {
                 new TableDescription()
                 {
-                    TableName = "first-table",
+                    TableName = "production-first-table",
                     ProvisionedThroughput = new ProvisionedThroughputDescription()
                     {
                         ReadCapacityUnits = 100,
@@ -380,7 +384,7 @@ namespace Watchman.Tests.Dynamo
             var alarmsByTable = cloudFormation
                 .Stack("Watchman-test")
                 .AlarmsByDimension("TableName");
-            var tableAlarms = alarmsByTable["first-table"];
+            var tableAlarms = alarmsByTable["production-first-table"];
 
             var consumedReadForTable = tableAlarms.SingleOrDefault(
                 a => a.Properties["AlarmName"].ToString()


### PR DESCRIPTION
1. Dynamo GSI alarms do not currently reference the table name, so don't work
2. Dynamo GSI alarms' logical name in cloudformation was previously based on the tablename, and was inadvertantly changed to GSI in previous PR. So this reverts to the way it worked before (which is a bit of a hack but that can be tidied once master is unbroken)