### PR TITLE
Add MonitorWrites option to dynamo to match old implementation

### DIFF
--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -164,6 +164,9 @@ For each resource each of the default alarms will be applied. See [alarm definit
 - `GsiReadThrottleEventsHigh`: 2
 - `GsiWriteThrottleEventsHigh`: 2
 
+#### Options
+- `MonitorWrites` Shorthand can be used to disable all the write alarms. Default is `true`.
+
 ### Sqs
 
 Sqs will mark any queue as an error queue if it ends with "_error"

--- a/Watchman.AwsResources/Services/DynamoDb/DynamoDbDataProvider.cs
+++ b/Watchman.AwsResources/Services/DynamoDb/DynamoDbDataProvider.cs
@@ -10,7 +10,7 @@ using Watchman.Configuration.Generic;
 namespace Watchman.AwsResources.Services.DynamoDb
 {
     public class DynamoDbDataProvider : IAlarmDimensionProvider<TableDescription>,
-        IResourceAttributesProvider<TableDescription, ResourceConfig>
+        IResourceAttributesProvider<TableDescription, DynamoResourceConfig>
     {
         public List<Dimension> GetDimensions(TableDescription resource, IList<string> dimensionNames)
         {
@@ -27,7 +27,7 @@ namespace Watchman.AwsResources.Services.DynamoDb
                 .Join(allowed, name => name, dim => dim.Name, (_, dim) => dim)
                 .ToList();
 
-            
+
 
             if (requested.Count != dimensionNames.Count)
             {
@@ -43,10 +43,10 @@ namespace Watchman.AwsResources.Services.DynamoDb
 
         private const int OneMinuteInSeconds = 60;
 
-        public Task<decimal> GetValue(TableDescription resource, ResourceConfig config, string property)
+        public Task<decimal> GetValue(TableDescription resource, DynamoResourceConfig config, string property)
         {
             // in future the multiplication by a minute shouldn't be hardcoded
-            // it's needed because the read capacity unit is in seconds, but our alarm is currently a sum over 1 minute. 
+            // it's needed because the read capacity unit is in seconds, but our alarm is currently a sum over 1 minute.
 
             switch (property)
             {

--- a/Watchman.AwsResources/Services/DynamoDb/DynamoDbGsiDataProvider.cs
+++ b/Watchman.AwsResources/Services/DynamoDb/DynamoDbGsiDataProvider.cs
@@ -9,7 +9,7 @@ using Watchman.Configuration.Generic;
 
 namespace Watchman.AwsResources.Services.DynamoDb
 {
-    public class DynamoDbGsiDataProvider : IResourceAttributesProvider<GlobalSecondaryIndexDescription, ResourceConfig>
+    public class DynamoDbGsiDataProvider : IResourceAttributesProvider<GlobalSecondaryIndexDescription, DynamoResourceConfig>
     {
         public List<Dimension> GetDimensions(GlobalSecondaryIndexDescription resource,
             TableDescription table,
@@ -47,7 +47,7 @@ namespace Watchman.AwsResources.Services.DynamoDb
 
         private const int OneMinuteInSeconds = 60;
 
-        public Task<decimal> GetValue(GlobalSecondaryIndexDescription resource, ResourceConfig config, string property)
+        public Task<decimal> GetValue(GlobalSecondaryIndexDescription resource, DynamoResourceConfig config, string property)
         {
             // in future the multiplication by a minute shouldn't be hardcoded
             // it's needed because the read capacity unit is in seconds, but our alarm is currently a sum over 1 minute.

--- a/Watchman.Configuration/AlertingGroupServices.cs
+++ b/Watchman.Configuration/AlertingGroupServices.cs
@@ -13,7 +13,7 @@ namespace Watchman.Configuration
         public AwsServiceAlarms<ResourceConfig> Elb { get; set; }
         public AwsServiceAlarms<ResourceConfig> KinesisStream { get; set; }
         public AwsServiceAlarms<ResourceConfig> StepFunction { get; set; }
-        public AwsServiceAlarms<ResourceConfig> DynamoDb { get; set; }
+        public AwsServiceAlarms<DynamoResourceConfig> DynamoDb { get; set; }
         public AwsServiceAlarms<SqsResourceConfig> Sqs { get; set; }
 
 

--- a/Watchman.Configuration/Generic/DynamoResourceConfig.cs
+++ b/Watchman.Configuration/Generic/DynamoResourceConfig.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Watchman.Configuration.Generic
+{
+    public class DynamoResourceConfig : IServiceAlarmConfig<DynamoResourceConfig>
+    {
+        public static bool MonitorWritesDefault = true;
+
+        public bool? MonitorWrites { get; set; }
+
+        public DynamoResourceConfig Merge(DynamoResourceConfig parentConfig)
+        {
+            if (parentConfig == null)
+            {
+                throw new ArgumentNullException(nameof(parentConfig));
+            }
+
+            return new DynamoResourceConfig()
+            {
+                MonitorWrites = MonitorWrites ?? parentConfig.MonitorWrites
+            };
+        }
+    }
+}

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -5,6 +5,159 @@ using Watchman.Configuration;
 
 namespace Watchman.Engine.Alarms
 {
+    public class DynamoDbDefaults
+    {
+        public IList<AlarmDefinition> DynamoDbGsiRead = new List<AlarmDefinition>()
+        {
+            new AlarmDefinition
+            {
+                Name = "GsiConsumedReadCapacityUnitsHigh",
+                Metric = "ConsumedReadCapacityUnits",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.PercentageOf,
+                    Value = AwsConstants.DefaultCapacityThreshold * 100,
+                    SourceAttribute = "ProvisionedReadThroughput"
+                },
+                DimensionNames = new[] { "GlobalSecondaryIndexName", "TableName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            },
+            new AlarmDefinition
+            {
+                Name = "GsiReadThrottleEventsHigh",
+                Metric = "ReadThrottleEvents",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.ThrottlingThreshold
+                },
+                DimensionNames = new[] { "GlobalSecondaryIndexName", "TableName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            }
+        };
+
+        public IList<AlarmDefinition> DynamoDbGsiWrite = new List<AlarmDefinition>()
+        {
+            new AlarmDefinition
+            {
+                Name = "GsiConsumedWriteCapacityUnitsHigh",
+                Metric = "ConsumedWriteCapacityUnits",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.PercentageOf,
+                    Value = AwsConstants.DefaultCapacityThreshold * 100,
+                    SourceAttribute = "ProvisionedWriteThroughput"
+                },
+                DimensionNames = new[] { "GlobalSecondaryIndexName", "TableName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            },
+            new AlarmDefinition
+            {
+                Name = "GsiWriteThrottleEventsHigh",
+                Metric = "WriteThrottleEvents",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.ThrottlingThreshold
+                },
+                DimensionNames = new[] { "GlobalSecondaryIndexName", "TableName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            }
+        };
+
+
+        public IList<AlarmDefinition> DynamoDbRead = new List<AlarmDefinition>
+        {
+            new AlarmDefinition
+            {
+                Name = "ConsumedReadCapacityUnitsHigh",
+                Metric = "ConsumedReadCapacityUnits",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.PercentageOf,
+                    Value = AwsConstants.DefaultCapacityThreshold * 100,
+                    SourceAttribute = "ProvisionedReadThroughput"
+                },
+                DimensionNames = new[] { "TableName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            },
+            new AlarmDefinition
+            {
+                Name = "ReadThrottleEventsHigh",
+                Metric = "ReadThrottleEvents",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.ThrottlingThreshold
+                },
+                DimensionNames = new[] { "TableName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            }
+        };
+
+
+        public IList<AlarmDefinition> DynamoDbWrite = new List<AlarmDefinition>
+        {
+            new AlarmDefinition
+            {
+                Name = "ConsumedWriteCapacityUnitsHigh",
+                Metric = "ConsumedWriteCapacityUnits",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.PercentageOf,
+                    Value = AwsConstants.DefaultCapacityThreshold * 100,
+                    SourceAttribute = "ProvisionedWriteThroughput"
+                },
+                DimensionNames = new[] { "TableName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            },
+            new AlarmDefinition
+            {
+                Name = "WriteThrottleEventsHigh",
+                Metric = "WriteThrottleEvents",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 1,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.ThrottlingThreshold
+                },
+                DimensionNames = new[] { "TableName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.DynamoDb
+            }
+        };
+    }
+
     /// <summary>
     ///  Alarms which will be applied to each service
     ///  The threshold can be overridden by the service or resource definition
@@ -25,7 +178,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.PercentageOf,
                     Value = 30
                 },
-                DimensionNames = new[] {"DBInstanceIdentifier"},
+                DimensionNames = new[] { "DBInstanceIdentifier" },
                 ComparisonOperator = ComparisonOperator.LessThanThreshold,
                 Statistic = Statistic.Minimum,
                 Namespace = AwsNamespace.Rds
@@ -41,7 +194,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 60
                 },
-                DimensionNames = new[] {"DBInstanceIdentifier"},
+                DimensionNames = new[] { "DBInstanceIdentifier" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Rds
@@ -57,7 +210,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 200
                 },
-                DimensionNames = new[] {"DBInstanceIdentifier"},
+                DimensionNames = new[] { "DBInstanceIdentifier" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Rds
@@ -77,7 +230,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 0.2
                 },
-                DimensionNames = new[] {"AutoScalingGroupName"},
+                DimensionNames = new[] { "AutoScalingGroupName" },
                 ComparisonOperator = ComparisonOperator.LessThanThreshold,
                 Statistic = Statistic.Minimum,
                 Namespace = AwsNamespace.Ec2
@@ -93,7 +246,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 90
                 },
-                DimensionNames = new[] {"AutoScalingGroupName"},
+                DimensionNames = new[] { "AutoScalingGroupName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Ec2
@@ -110,7 +263,7 @@ namespace Watchman.Engine.Alarms
                     Value = 50,
                     SourceAttribute = "GroupDesiredCapacity"
                 },
-                DimensionNames = new[] {"AutoScalingGroupName"},
+                DimensionNames = new[] { "AutoScalingGroupName" },
                 ComparisonOperator = ComparisonOperator.LessThanThreshold,
                 Statistic = Statistic.Minimum,
                 Namespace = AwsNamespace.AutoScaling
@@ -130,7 +283,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 3
                 },
-                DimensionNames = new[] {"FunctionName"},
+                DimensionNames = new[] { "FunctionName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Lambda
@@ -147,7 +300,7 @@ namespace Watchman.Engine.Alarms
                     Value = 50,
                     SourceAttribute = "Timeout"
                 },
-                DimensionNames = new[] {"FunctionName"},
+                DimensionNames = new[] { "FunctionName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Lambda
@@ -163,7 +316,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 5
                 },
-                DimensionNames = new[] {"FunctionName"},
+                DimensionNames = new[] { "FunctionName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Lambda
@@ -179,7 +332,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 300000
                 },
-                DimensionNames = new[] {"FunctionName"},
+                DimensionNames = new[] { "FunctionName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Lambda
@@ -196,7 +349,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 1
                 },
-                DimensionNames = new[] {"FunctionName"},
+                DimensionNames = new[] { "FunctionName" },
                 ComparisonOperator = ComparisonOperator.LessThanThreshold,
                 Statistic = Statistic.SampleCount,
                 Namespace = AwsNamespace.Lambda
@@ -217,7 +370,7 @@ namespace Watchman.Engine.Alarms
                     SourceAttribute = "NumberOfIpAddresses",
                     Value = 30
                 },
-                DimensionNames = new[] {"Subnet"},
+                DimensionNames = new[] { "Subnet" },
                 ComparisonOperator = ComparisonOperator.LessThanOrEqualToThreshold,
                 Statistic = Statistic.Minimum,
                 Namespace = "JUSTEAT/PlatformLimits",
@@ -238,7 +391,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 50
                 },
-                DimensionNames = new[] {"LoadBalancerName"},
+                DimensionNames = new[] { "LoadBalancerName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Elb
@@ -254,7 +407,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 500
                 },
-                DimensionNames = new[] {"LoadBalancerName"},
+                DimensionNames = new[] { "LoadBalancerName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Elb
@@ -270,7 +423,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 200
                 },
-                DimensionNames = new[] {"LoadBalancerName"},
+                DimensionNames = new[] { "LoadBalancerName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Elb
@@ -286,7 +439,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 10
                 },
-                DimensionNames = new[] {"LoadBalancerName"},
+                DimensionNames = new[] { "LoadBalancerName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Elb
@@ -302,7 +455,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 0.50
                 },
-                DimensionNames = new[] {"LoadBalancerName"},
+                DimensionNames = new[] { "LoadBalancerName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 // This should be probably a percentile statistic once that is supported via cloudformation
                 Statistic = Statistic.Average,
@@ -319,7 +472,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 1
                 },
-                DimensionNames = new[] {"LoadBalancerName"},
+                DimensionNames = new[] { "LoadBalancerName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Elb
@@ -339,7 +492,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 1
                 },
-                DimensionNames = new[] {"StreamName"},
+                DimensionNames = new[] { "StreamName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Kinesis
@@ -355,7 +508,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 1
                 },
-                DimensionNames = new[] {"StreamName"},
+                DimensionNames = new[] { "StreamName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Kinesis
@@ -376,150 +529,10 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = 1
                 },
-                DimensionNames = new[] {"StateMachineArn"},
+                DimensionNames = new[] { "StateMachineArn" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.StepFunction
-            }
-        };
-
-        public static IList<AlarmDefinition> DynamoDbGsi = new List<AlarmDefinition>()
-        {
-            new AlarmDefinition
-            {
-                Name = "GsiConsumedReadCapacityUnitsHigh",
-                Metric = "ConsumedReadCapacityUnits",
-                Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
-                Threshold = new Threshold
-                {
-                    ThresholdType = ThresholdType.PercentageOf,
-                    Value = AwsConstants.DefaultCapacityThreshold * 100,
-                    SourceAttribute = "ProvisionedReadThroughput"
-                },
-                DimensionNames = new[] {"GlobalSecondaryIndexName", "TableName"},
-                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
-            },
-            new AlarmDefinition
-            {
-                Name = "GsiConsumedWriteCapacityUnitsHigh",
-                Metric = "ConsumedWriteCapacityUnits",
-                Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
-                Threshold = new Threshold
-                {
-                    ThresholdType = ThresholdType.PercentageOf,
-                    Value = AwsConstants.DefaultCapacityThreshold * 100,
-                    SourceAttribute = "ProvisionedWriteThroughput"
-                },
-                DimensionNames = new[] {"GlobalSecondaryIndexName", "TableName"},
-                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
-            },
-            new AlarmDefinition
-            {
-                Name = "GsiReadThrottleEventsHigh",
-                Metric = "ReadThrottleEvents",
-                Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
-                Threshold = new Threshold
-                {
-                    ThresholdType = ThresholdType.Absolute,
-                    Value = AwsConstants.ThrottlingThreshold
-                },
-                DimensionNames = new[] {"GlobalSecondaryIndexName", "TableName"},
-                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
-            },
-            new AlarmDefinition
-            {
-                Name = "GsiWriteThrottleEventsHigh",
-                Metric = "WriteThrottleEvents",
-                Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
-                Threshold = new Threshold
-                {
-                    ThresholdType = ThresholdType.Absolute,
-                    Value = AwsConstants.ThrottlingThreshold
-                },
-                DimensionNames = new[] {"GlobalSecondaryIndexName", "TableName"},
-                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
-            }
-        };
-
-        public static IList<AlarmDefinition> DynamoDb = new List<AlarmDefinition>
-        {
-            new AlarmDefinition
-            {
-                Name = "ConsumedReadCapacityUnitsHigh",
-                Metric = "ConsumedReadCapacityUnits",
-                Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
-                Threshold = new Threshold
-                {
-                    ThresholdType = ThresholdType.PercentageOf,
-                    Value = AwsConstants.DefaultCapacityThreshold * 100,
-                    SourceAttribute = "ProvisionedReadThroughput"
-                },
-                DimensionNames = new[] {"TableName"},
-                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
-            },
-            new AlarmDefinition
-            {
-                Name = "ConsumedWriteCapacityUnitsHigh",
-                Metric = "ConsumedWriteCapacityUnits",
-                Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
-                Threshold = new Threshold
-                {
-                    ThresholdType = ThresholdType.PercentageOf,
-                    Value = AwsConstants.DefaultCapacityThreshold * 100,
-                    SourceAttribute = "ProvisionedWriteThroughput"
-                },
-                DimensionNames = new[] {"TableName"},
-                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
-            },
-            new AlarmDefinition
-            {
-                Name = "ReadThrottleEventsHigh",
-                Metric = "ReadThrottleEvents",
-                Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
-                Threshold = new Threshold
-                {
-                    ThresholdType = ThresholdType.Absolute,
-                    Value = AwsConstants.ThrottlingThreshold
-                },
-                DimensionNames = new[] {"TableName"},
-                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
-            },
-            new AlarmDefinition
-            {
-                Name = "WriteThrottleEventsHigh",
-                Metric = "WriteThrottleEvents",
-                Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
-                Threshold = new Threshold
-                {
-                    ThresholdType = ThresholdType.Absolute,
-                    Value = AwsConstants.ThrottlingThreshold
-                },
-                DimensionNames = new[] {"TableName"},
-                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
             }
         };
 
@@ -536,7 +549,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = AwsConstants.QueueLengthThreshold
                 },
-                DimensionNames = new[] {"QueueName"},
+                DimensionNames = new[] { "QueueName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Sqs
@@ -548,11 +561,11 @@ namespace Watchman.Engine.Alarms
                 Period = TimeSpan.FromMinutes(5),
                 EvaluationPeriods = 1,
                 Threshold = new Threshold
-                            {
-                                ThresholdType = ThresholdType.Absolute,
-                                Value = AwsConstants.OldestMessageThreshold
-                            },
-                DimensionNames = new[] {"QueueName"},
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.OldestMessageThreshold
+                },
+                DimensionNames = new[] { "QueueName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Sqs
@@ -572,7 +585,7 @@ namespace Watchman.Engine.Alarms
                     ThresholdType = ThresholdType.Absolute,
                     Value = AwsConstants.ErrorQueueLengthThreshold
                 },
-                DimensionNames = new[] {"QueueName"},
+                DimensionNames = new[] { "QueueName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.Sqs
@@ -584,11 +597,11 @@ namespace Watchman.Engine.Alarms
                 Period = TimeSpan.FromMinutes(5),
                 EvaluationPeriods = 1,
                 Threshold = new Threshold
-                            {
-                                ThresholdType = ThresholdType.Absolute,
-                                Value = AwsConstants.OldestMessageThreshold
-                            },
-                DimensionNames = new[] {"QueueName"},
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = AwsConstants.OldestMessageThreshold
+                },
+                DimensionNames = new[] { "QueueName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Sqs

--- a/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
+++ b/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
@@ -52,7 +52,7 @@ namespace Watchman.Engine.Generation
             return Map(input, id, a => a?.Services?.StepFunction);
         }
 
-        public static WatchmanServiceConfiguration<ResourceConfig> MapDynamoDb(WatchmanConfiguration input)
+        public static WatchmanServiceConfiguration<DynamoResourceConfig> MapDynamoDb(WatchmanConfiguration input)
         {
             const string id = "DynamoDb";
             return Map(input, id, a => a?.Services?.DynamoDb);

--- a/Watchman.Tests/MultipleServiceAlarmTests.cs
+++ b/Watchman.Tests/MultipleServiceAlarmTests.cs
@@ -39,11 +39,11 @@ namespace Watchman.Tests
                 "group-suffix",
                 new AlertingGroupServices()
                 {
-                    DynamoDb = new AwsServiceAlarms<ResourceConfig>()
+                    DynamoDb = new AwsServiceAlarms<DynamoResourceConfig>()
                     {
-                        Resources = new List<ResourceThresholds<ResourceConfig>>()
+                        Resources = new List<ResourceThresholds<DynamoResourceConfig>>()
                         {
-                            new ResourceThresholds<ResourceConfig>()
+                            new ResourceThresholds<DynamoResourceConfig>()
                             {
                                 Name = "first-dynamo-table"
                             }
@@ -89,7 +89,7 @@ namespace Watchman.Tests
             });
 
             var sut = ioc.Get<AlarmLoaderAndGenerator>();
-            
+
             // act
 
             await sut.LoadAndGenerateAlarms(RunMode.GenerateAlarms);

--- a/Watchman/IoC/AwsServiceRegistry.cs
+++ b/Watchman/IoC/AwsServiceRegistry.cs
@@ -62,8 +62,8 @@ namespace Watchman.IoC
                 WatchmanServiceConfigurationMapper.MapStepFunction, Defaults.StepFunction
             );
 
-            AddService<TableDescription, TableDescriptionSource, DynamoDbDataProvider, ResourceConfig, DynamoResourceAlarmGenerator>(
-                WatchmanServiceConfigurationMapper.MapDynamoDb, Defaults.DynamoDb);
+            AddService<TableDescription, TableDescriptionSource, DynamoDbDataProvider, DynamoResourceConfig, DynamoResourceAlarmGenerator>(
+                WatchmanServiceConfigurationMapper.MapDynamoDb, null);
 
 
             AddService<QueueDataV2, QueueDataV2Source, QueueDataProvider, SqsResourceConfig, SqsResourceAlarmGenerator>(
@@ -109,7 +109,10 @@ namespace Watchman.IoC
 
             For<IResourceAlarmGenerator<TServiceModel, TResourceAlarmConfig>>().Use<TAlarmBuilder>();
 
-            For<AlarmDefaults<TServiceModel>>().Use(_ => AlarmDefaults<TServiceModel>.FromDefaults(defaults));
+            if (defaults != null)
+            {
+                For<AlarmDefaults<TServiceModel>>().Use(_ => AlarmDefaults<TServiceModel>.FromDefaults(defaults));
+            }
         }
     }
 }


### PR DESCRIPTION
So you can disable the write alarms without having to name every alarm which is looking at writes