### PR TITLE
Rough documentation updates

### DIFF
--- a/ConfigurationFileFormat.md
+++ b/ConfigurationFileFormat.md
@@ -3,7 +3,7 @@
 Configuration is read from a folder. Typically we use one folder per environment, containing one file per team.
 Each file contains an "alerting group".
 
- The alerting group has some top-level data such as `Name`, some data about `Targets` that alerts and reports are sent to, and then markup about AWS resources: the `DynamoDb` and `Sqs` elements. This specifies which resources the team claims, and configuration on how to monitor them. Configuration files are validated when loaded, and each file must contain at least one of these AWS resource sections.
+ The alerting group has some top-level data such as `Name`, some data about `Targets` that alerts and reports are sent to, and then markup about AWS resources: the `Services` element. This specifies which resources the team claims, and configuration on how to monitor them. Configuration files are validated when loaded, and each file must contain at least one of these AWS resource sections.
 
 ## AlertingGroup
 
@@ -15,13 +15,11 @@ Each file contains an "alerting group".
 | Targets | Array of `Target` | Required | Must contain at least one target.<br> See below more info on `Targets`. |
 | ReportTargets | Array of `ReportTarget` | | List of email addresses to mail the provisioning report to, for use with Quartermaster |
 | IsCatchAll | Boolean | Default is `false` |If `true`, this group is not inspected when generating the lists of unmonitored resources, and it can include resources monitored by this group.|
-| DynamoDb | a `DynamoDb` object | ** <br/> Optional | Describes the DynamoDB tables to monitor. |
-| Sqs| a `Sqs` object | ** <br/> Optional | Describes the SQS queues to monitor. |
-|Services| Generic services| ** <br/> Optional | Describes the services to monitor. |
+|Services| services| Required | Describes the services to monitor. |
 
 __NOTES:__
 
-** Each AlertingGroup must specify services to monitor in some form, i.e. either the `DynamoDb`, `Sqs`, or `Services` element containing some [supported services](SupportedServices.md).
+** Each AlertingGroup must specify services to monitor in some form.
 
 #### Targets
 
@@ -34,74 +32,6 @@ Targets receive the alerts - they are added to the SNS subscriptions for each cl
 
 To get a Url for PagerDuty integration, use the "In pagerDuty" section of the [PagerDuty / AWS CloudWatch Integration Guide](https://www.pagerduty.com/docs/guides/aws-cloudwatch-integration-guide/).
 
-### DynamoDb configuration sections
+### Services sections
 
-
-#### DynamoDb 
-
-| Field | Type | Value | Description |
-|-------|------|-----------|------------|
-| Threshold | Decimal | Default is `0.8` (ie 80%) | The used as a percentage of the capacity to work out the alarm thresholds. Will be used as threshold of all tables listed in an AlertingGroup unless overridden for a table. |
-| MonitorThrottling | bool | Default is false | Enables monitoring on throttled reads or writes. |
-| ThrottlingThreshold| int| Optional | Set the throttling threshold - the number of throttled reads or writes in a minute that causes an alarm. |
-| Tables | Array of `Table` | ** | Array of dynamo tables to add the alerts to.<br>See below for more info on `Tables` |
-| ExcludeTablesPrefixedWith | Array of strings | | Don't add read or write alerts for any tables with these name prefixes.<br>Exclude overrides `Tables` settings.  |
-| ExcludeReadsForTablesPrefixedWith | Array of strings |  | Don't add read alerts for any tables with these name prefixes.<br>Exclude overrides `Tables` settings.)  |
-| ExcludeWritesForTablesPrefixedWith | Array of strings | | Don't add write alerts for any tables with these name prefixes.<br>Exclude overrides `Tables` settings.  |
-
-
-#### Tables
-
-Tables can either be added as strings or Table objects. If added as simple strings, the default options will used.
-
-| Field | Type | Value | Description |
-|-------|------|-------|-------------|
-| Name | String | One of `Name` or `Pattern` must be specified | Name of the dynamo table |
-| Pattern | String | One of `Name` or `Pattern` must be specified | Regex to match multiple dynamo tables |
-| Threshold | Decimal | Default from the `Threshold` value of containing alerting group. | Used as a fraction of the capacity to work out the alarm threshold for this table *** |
-| MonitorWrites | Boolean | Default is `true` | If `false`, no alerts are generated for writes to the table or its indexes |
-| MonitorThrottling | bool | Default from the `MonitorThrottling` value of containing alerting group. | Enables or disables monitoring on throttled reads or writes. |
-| ThrottlingThreshold| int| Default from the `ThrottlingThreshold` value of containing alerting group. | Set the throttling threshold - the number of throttled reads or writes in a minute that causes an alarm. |
-
-
-*** The alerting Threshold is a value from 0.0 to 1.0 that specifies the fraction of the table's read or write capacity being used that triggers the cloudwatch alarm. The threshold for a table uses these fallbacks:
- - if a threshold is specified for the table, that is used. If not,
- - if a threshold is specified for the containing alerting group, that is used. If not,
- - a global default of 0.8 (i.e. 80% utilisation) is used.
-
-All global secondary indexes on the table will also be monitored at the same threshold.
-
-### Sqs configuration sections
-
-### Sqs
-
-| Field | Type | Value | Description |
-|-------|------|-------|-------------|
-| LengthThreshold | int, count of messages | Optional | Value for alert on queue length |
-| OldestMessageThreshold | int, number of seconds | Optional | Value for alert on old messages |
-| Errors | error queue data | Optional | Default configuration of error queues |
-| Queues | Array of queue |  |  |
-
-### Queue
-
-| Field | Type | Value | Description |
-|-------|------|-------|-------------|
-| Name | String | One of `Name` or `Pattern` must be specified | Name of the queue |
-| Pattern | String | One of `Name` or `Pattern` must be specified | Regex to match multiple queues |
-| LengthThreshold | int, count of messages | Optional | Value for alert on queue length |
-| OldestMessageThreshold | int, number of seconds | Optional | Value for alert on age of messages in a queue |
-| Errors | error queue data | Optional | Values for alerts on error queues |
-
-### Errors
-
-Can be attached to Queue or alerting group or both. Values are defaulted - if a value is not specified in a queue, the default from the alerting group is used. If that is not specified, then a global default is used.
-
-| Field | Type | Value | Description |
-|-------|------|-------|-------------|
-| Monitored | bool | Optional, default _true_ | Should this error queue be monitored at all. If False, none of the other values in the Errors object are used  |
-| Suffix | string | Optional, default is "_error" | Text at the end of queue name to determine if this is an error queue |
-| LengthThreshold | int, count of messages | Optional | Value for alert on error queue length |
-| OldestMessageThreshold  | int, number of seconds | Optional | Value for alert on age of messages in an error queue |
-
-
-This looks complex, but the defaults are overrides are aimed at producing readable and sensible markup, while dealing with the way that queues are set up in a variety of ways: in some cases the team needs to know about even 1 message arriving on an error queue, while in others the error queue is ignored, or does not exist.
+See [Supported Services](SupportedServices.md) 

--- a/ConfigurationFileFormat.md
+++ b/ConfigurationFileFormat.md
@@ -16,7 +16,8 @@ Each file contains an "alerting group".
 | ReportTargets | Array of `ReportTarget` | | List of email addresses to mail the provisioning report to, for use with Quartermaster |
 | IsCatchAll | Boolean | Default is `false` |If `true`, this group is not inspected when generating the lists of unmonitored resources, and it can include resources monitored by this group.|
 |Services| services| Required | Describes the services to monitor. |
-
+|NumberOfCloudFormationStacks| int |  Optional (default 1) | Divide alarms between this many CloudFormation stacks. CloudFormation stacks have some hard limits on number of resources and template file size. Do not reduce this value once you have set it and deployed stacks, unless you manually delete the stacks first. | 
+ 
 __NOTES:__
 
 ** Each AlertingGroup must specify services to monitor in some form.

--- a/LegacyConfiguration.md
+++ b/LegacyConfiguration.md
@@ -1,0 +1,70 @@
+## Legacy configuration
+
+#### DynamoDb 
+
+| Field | Type | Value | Description |
+|-------|------|-----------|------------|
+| Threshold | Decimal | Default is `0.8` (ie 80%) | The used as a percentage of the capacity to work out the alarm thresholds. Will be used as threshold of all tables listed in an AlertingGroup unless overridden for a table. |
+| MonitorThrottling | bool | Default is false | Enables monitoring on throttled reads or writes. |
+| ThrottlingThreshold| int| Optional | Set the throttling threshold - the number of throttled reads or writes in a minute that causes an alarm. |
+| Tables | Array of `Table` | ** | Array of dynamo tables to add the alerts to.<br>See below for more info on `Tables` |
+| ExcludeTablesPrefixedWith | Array of strings | | Don't add read or write alerts for any tables with these name prefixes.<br>Exclude overrides `Tables` settings.  |
+| ExcludeReadsForTablesPrefixedWith | Array of strings |  | Don't add read alerts for any tables with these name prefixes.<br>Exclude overrides `Tables` settings.)  |
+| ExcludeWritesForTablesPrefixedWith | Array of strings | | Don't add write alerts for any tables with these name prefixes.<br>Exclude overrides `Tables` settings.  |
+
+
+#### Tables
+
+Tables can either be added as strings or Table objects. If added as simple strings, the default options will used.
+
+| Field | Type | Value | Description |
+|-------|------|-------|-------------|
+| Name | String | One of `Name` or `Pattern` must be specified | Name of the dynamo table |
+| Pattern | String | One of `Name` or `Pattern` must be specified | Regex to match multiple dynamo tables |
+| Threshold | Decimal | Default from the `Threshold` value of containing alerting group. | Used as a fraction of the capacity to work out the alarm threshold for this table *** |
+| MonitorWrites | Boolean | Default is `true` | If `false`, no alerts are generated for writes to the table or its indexes |
+| MonitorThrottling | bool | Default from the `MonitorThrottling` value of containing alerting group. | Enables or disables monitoring on throttled reads or writes. |
+| ThrottlingThreshold| int| Default from the `ThrottlingThreshold` value of containing alerting group. | Set the throttling threshold - the number of throttled reads or writes in a minute that causes an alarm. |
+
+
+*** The alerting Threshold is a value from 0.0 to 1.0 that specifies the fraction of the table's read or write capacity being used that triggers the cloudwatch alarm. The threshold for a table uses these fallbacks:
+ - if a threshold is specified for the table, that is used. If not,
+ - if a threshold is specified for the containing alerting group, that is used. If not,
+ - a global default of 0.8 (i.e. 80% utilisation) is used.
+
+All global secondary indexes on the table will also be monitored at the same threshold.
+
+### Sqs configuration sections
+
+### Sqs
+
+| Field | Type | Value | Description |
+|-------|------|-------|-------------|
+| LengthThreshold | int, count of messages | Optional | Value for alert on queue length |
+| OldestMessageThreshold | int, number of seconds | Optional | Value for alert on old messages |
+| Errors | error queue data | Optional | Default configuration of error queues |
+| Queues | Array of queue |  |  |
+
+### Queue
+
+| Field | Type | Value | Description |
+|-------|------|-------|-------------|
+| Name | String | One of `Name` or `Pattern` must be specified | Name of the queue |
+| Pattern | String | One of `Name` or `Pattern` must be specified | Regex to match multiple queues |
+| LengthThreshold | int, count of messages | Optional | Value for alert on queue length |
+| OldestMessageThreshold | int, number of seconds | Optional | Value for alert on age of messages in a queue |
+| Errors | error queue data | Optional | Values for alerts on error queues |
+
+### Errors
+
+Can be attached to Queue or alerting group or both. Values are defaulted - if a value is not specified in a queue, the default from the alerting group is used. If that is not specified, then a global default is used.
+
+| Field | Type | Value | Description |
+|-------|------|-------|-------------|
+| Monitored | bool | Optional, default _true_ | Should this error queue be monitored at all. If False, none of the other values in the Errors object are used  |
+| Suffix | string | Optional, default is "_error" | Text at the end of queue name to determine if this is an error queue |
+| LengthThreshold | int, count of messages | Optional | Value for alert on error queue length |
+| OldestMessageThreshold  | int, number of seconds | Optional | Value for alert on age of messages in an error queue |
+
+
+This looks complex, but the defaults are overrides are aimed at producing readable and sensible markup, while dealing with the way that queues are set up in a variety of ways: in some cases the team needs to know about even 1 message arriving on an error queue, while in others the error queue is ignored, or does not exist.

--- a/README.md
+++ b/README.md
@@ -110,17 +110,7 @@ The user associated with the keys needs to be in several roles. These are all do
 
 ## Alerts on
 
-Alerts are generated at configurable thresholds on the following CloudWatch metrics:
-
-* DynamoDb:
-  * ConsumedReadCapacityUnits 
-  * ConsumedWriteCapacityUnits
-  * ReadThrottleEvents
-  * WriteThrottleEvents
-* SQS:
-  * ApproximateNumberOfMessagesVisible
-  * ApproximateAgeOfOldestMessage
-
+See [Supported Services](SupportedServices.md) for supported AWS services.
 
 ### Run sequence
 
@@ -132,7 +122,7 @@ When run, `Watchman` does things in approximately this order:
 - for each resource type, across all alerting groups:
   - Populate resource names. Expand regexp patterns into full resource names that match the pattern.
   - For the set of alarm definitions for each service (e.g. DynamoDB, SQS, RDS), apply either the default threshold from those definitions, or from the alerting group, or from the specific resource definition, depending on what is defined.
- - Create alarm models and create CloudFormation from them. For legacy reasons, DynamoDB, SQS are different, they put alarms directly. We may convert them later.
+ - Create alarm models and create CloudFormation from them. 
  - Commit the changes. Skipped if the run mode is `DryRun`.
  - Report on "orphans", i.e. resources that are not covered by any alarms in alerting group, excluding "CatchAll" groups.
 

--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -173,6 +173,10 @@ Sqs will mark any queue as an error queue if it ends with "_error"
 - `NumberOfMessagesVisible_Error`: 10
 - `AgeOfOldestMessage_Error`: 600 (seconds)
 
+#### Options
+
+- `IncludeErrorQueues`: Enable special handling of _error queues matching the primary queue name (default `true`)
+
 ### VpcSubnets
 
 - `IpAddressesRemainingLow` 30 (% of subnet allocation)


### PR DESCRIPTION
Now that we can support all services via the newer mechanism, we can update docs to reflect that being the preferred way now.

Also added missing option for SQS and number of CloudFormation stacks