### PR TITLE
Ignore missing tables that are named (in legacy impl)

### DIFF
--- a/Watchman.AwsResources.Tests/Services/DynamoDb/TableDescriptionSourceTests.cs
+++ b/Watchman.AwsResources.Tests/Services/DynamoDb/TableDescriptionSourceTests.cs
@@ -137,5 +137,12 @@ namespace Watchman.AwsResources.Tests.Services.DynamoDb
             Assert.That(result.Resource, Is.InstanceOf<TableDescription>());
             Assert.That(result.Resource.TableName, Is.EqualTo(secondDbInstanceName));
         }
+
+        [Test]
+        public async Task GetResouceAsync_ReturnsNullIfNotInList()
+        {
+            var result = await _tableDescriptionSource.GetResourceAsync("does-not-exist");
+            Assert.Null(result);
+        }
     }
 }

--- a/Watchman.AwsResources.Tests/Services/DynamoDb/TableDescriptionSourceTests.cs
+++ b/Watchman.AwsResources.Tests/Services/DynamoDb/TableDescriptionSourceTests.cs
@@ -139,7 +139,7 @@ namespace Watchman.AwsResources.Tests.Services.DynamoDb
         }
 
         [Test]
-        public async Task GetResouceAsync_ReturnsNullIfNotInList()
+        public async Task GetResourceAsync_ReturnsNullIfNotInList()
         {
             var result = await _tableDescriptionSource.GetResourceAsync("does-not-exist");
             Assert.Null(result);

--- a/Watchman.AwsResources/Services/DynamoDb/TableDescriptionSource.cs
+++ b/Watchman.AwsResources/Services/DynamoDb/TableDescriptionSource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
@@ -28,6 +29,16 @@ namespace Watchman.AwsResources.Services.DynamoDb
 
         public async Task<AwsResource<TableDescription>> GetResourceAsync(string name)
         {
+            if (_tableNames == null)
+            {
+                await GetResourceNamesAsync();
+            }
+
+            if (!_tableNames.Contains(name))
+            {
+                return null;
+            }
+
             if (_cachedTableDescriptions.ContainsKey(name))
             {
                 return _cachedTableDescriptions[name];

--- a/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/MissingResources.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/MissingResources.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.Model;
+using Moq;
+using NUnit.Framework;
+using Watchman.AwsResources;
+using Watchman.AwsResources.Services.Sqs;
+using Watchman.Configuration;
+using Watchman.Engine.Generation.Dynamo;
+using Watchman.Engine.Generation.Sqs;
+using Watchman.Engine.Logging;
+using Watchman.Engine.Sns;
+using Watchman.Engine.Tests.Generation.Sqs;
+
+namespace Watchman.Engine.Tests.Generation.Dynamo.AlarmGeneratorTests
+{
+    [TestFixture]
+    public class MissingResources
+    {
+        [Test]
+        public async Task NamedTableThatDoesNotExistIsIgnored()
+        {
+
+            var mockery = new DynamoAlarmGeneratorMockery();
+            var generator = mockery.AlarmGenerator;
+
+            ConfigureTables(mockery);
+
+            var config = new WatchmanConfiguration()
+            {
+                AlertingGroups = new List<AlertingGroup>()
+                {
+                    new AlertingGroup()
+                    {
+                        Name = "TestGroup",
+                        AlarmNameSuffix = "TestGroup",
+                        DynamoDb = new DynamoDb()
+                        {
+                            Tables = new List<Table>
+                            {
+                                new Table { Name = "table-that-exists" },
+                                new Table { Name = "missing-table" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            await generator.GenerateAlarmsFor(config, RunMode.GenerateAlarms);
+
+            CloudwatchVerify.AlarmWasPutOnTable(mockery.Cloudwatch,
+                alarmName: "table-that-exists-ConsumedWriteCapacityUnits-TestGroup",
+                tableName: "table-that-exists",
+                metricName: "ConsumedWriteCapacityUnits",
+                threshold: 144000,
+                period: 300);
+        }
+
+        private static void ConfigureTables(DynamoAlarmGeneratorMockery mockery)
+        {
+            mockery.GivenATable("table-that-exists", 1300, 600);
+            mockery.ValidSnsTopic();
+        }
+    }
+}

--- a/Watchman.Engine/Generation/Dynamo/DynamoAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Dynamo/DynamoAlarmGenerator.cs
@@ -105,6 +105,13 @@ namespace Watchman.Engine.Generation.Dynamo
             try
             {
                 var tableResource = await _tableSource.GetResourceAsync(table.Name);
+
+                if (tableResource == null)
+                {
+                    _logger.Info($"Skipping named table {table.Name} as it does not exist");
+                    return;
+                }
+
                 var tableDescription = tableResource.Resource;
                 var threshold = table.Threshold ?? alarmTables.Threshold;
 
@@ -163,6 +170,13 @@ namespace Watchman.Engine.Generation.Dynamo
             try
             {
                 var tableResource = await _tableSource.GetResourceAsync(table.Name);
+
+                if (tableResource == null)
+                {
+                    _logger.Info($"Skipping named table {table.Name} as it does not exist");
+                    return;
+                }
+
                 var tableDescription = tableResource.Resource;
                 var threshold = table.Threshold ?? alarmTables.Threshold;
 


### PR DESCRIPTION
I initially started by using the approach in the newer service implementations where a `named-table` is converted to a pattern of `^named-table$` very early on. However this made a lot of tests fail and I'm worried it impact other things such as prioritisation - e.g. if you had a named table and a pattern that both pointed to the same table. This approach solves the problem and no existing tests broke.

fix for #226 