### PR TITLE
Adding new type of alert for lambdas - Invocation High

### DIFF
--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -143,6 +143,7 @@ For each resource each of the default alarms will be applied. See [alarm definit
 - `DurationHigh`: 50 (% of defined Timeout)
 - `ThrottlesHigh`: 5 (count)
 - `InvocationsLow`: Disabled by default. If enabled it checks the function was executed at least once in a day.
+- `InvocationsHigh`: Disabled by default. If enabled it checks the function was executed at most x in a day.
 
 ### Kinesis
 

--- a/Watchman.Configuration.Tests/Load/ConfigFileLoaderThresholdTests.cs
+++ b/Watchman.Configuration.Tests/Load/ConfigFileLoaderThresholdTests.cs
@@ -104,6 +104,7 @@ namespace Watchman.Configuration.Tests.Load
             Assert.That(section.Values["FloatValueAsString"].Threshold, Is.EqualTo(2.2));
             Assert.That(section.Values["IntValueAsString"].Threshold, Is.EqualTo(41));
             Assert.That(section.Values["InvocationsLow"].Threshold, Is.EqualTo(5));
+            Assert.That(section.Values["InvocationsHigh"].Threshold, Is.EqualTo(10));
         }
 
         [Test]

--- a/Watchman.Configuration.Tests/data/withThresholds/Lambda.json
+++ b/Watchman.Configuration.Tests/data/withThresholds/Lambda.json
@@ -27,7 +27,8 @@
         "FloatValue": 2.1,
         "FloatValueAsString": "2.2",
         "IntValueAsString": "41",
-        "InvocationsLow": 5
+        "InvocationsLow": 5,
+        "InvocationsHigh": 10 
       }
     }
   }

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -353,6 +353,23 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.LessThanThreshold,
                 Statistic = Statistic.SampleCount,
                 Namespace = AwsNamespace.Lambda
+            },
+            new AlarmDefinition
+            {
+                Name = "InvocationsHigh",
+                Enabled = false,
+                Metric = "Invocations",
+                Period = TimeSpan.FromMinutes(5),
+                EvaluationPeriods = 288,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = 1
+                },
+                DimensionNames = new[] { "FunctionName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.SampleCount,
+                Namespace = AwsNamespace.Lambda
             }
         };
 

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+dotnet test Quartermaster.Tests/Quartermaster.Tests.csproj
+dotnet test Watchman.AwsResources.Tests/Watchman.AwsResources.Tests.csproj
+dotnet test Watchman.Configuration.Tests/Watchman.Configuration.Tests.csproj
+dotnet test Watchman.Engine.Tests/Watchman.Engine.Tests.csproj


### PR DESCRIPTION
This can be used when setting a invocation alert for lambda to be executed 'exactly' 'x'.

Example: Exactly once

InvocationsLow: 1
InvocationsHigh: 2