### PR TITLE
Update AWS SDK and apply fixes

### DIFF
--- a/Quartermaster/ReportGenerator.cs
+++ b/Quartermaster/ReportGenerator.cs
@@ -158,8 +158,8 @@ namespace QuarterMaster
             var allDataPoints = new List<Datapoint>();
             for (var i = 0; i <= ReportDuration; i++)
             {
-                getMetricsRequest.StartTime = DateTime.UtcNow.AddDays(-(i + 1));
-                getMetricsRequest.EndTime = DateTime.UtcNow.AddDays(-i);
+                getMetricsRequest.StartTimeUtc = DateTime.UtcNow.AddDays(-(i + 1));
+                getMetricsRequest.EndTimeUtc = DateTime.UtcNow.AddDays(-i);
                 allDataPoints.AddRange((await _cloudwatch.GetMetricStatisticsAsync(getMetricsRequest)).Datapoints);
             }
             return allDataPoints.Count > 0 ? allDataPoints.Max(x => x.Sum) : 0;

--- a/TestHelper/TestHelper.csproj
+++ b/TestHelper/TestHelper.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.27.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
   </ItemGroup>
 </Project>

--- a/Watchman.AwsResources/Services/AutoScaling/AutoScalingGroupAlarmDataProvider.cs
+++ b/Watchman.AwsResources/Services/AutoScaling/AutoScalingGroupAlarmDataProvider.cs
@@ -67,22 +67,22 @@ namespace Watchman.AwsResources.Services.AutoScaling
             var now = _timeProvider.UtcNow;
 
             var metric = await _cloudWatch.GetMetricStatisticsAsync(
-                new GetMetricStatisticsRequest()
+                new GetMetricStatisticsRequest
                 {
-                    Dimensions = new List<Dimension>()
+                    Dimensions = new List<Dimension>
                     {
-                        new Dimension()
+                        new Dimension
                         {
                             Name = "AutoScalingGroupName",
                             Value = resource.AutoScalingGroupName
                         }
                     },
-                    Statistics = new List<string>() {"Minimum"},
+                    Statistics = new List<string> {"Minimum"},
                     Namespace = "AWS/AutoScaling",
                     Period = delaySeconds,
                     MetricName = "GroupDesiredCapacity",
-                    StartTime = now.AddSeconds(-1 * delaySeconds),
-                    EndTime = now
+                    StartTimeUtc = now.AddSeconds(-1 * delaySeconds),
+                    EndTimeUtc = now
                 }
             );
 
@@ -111,7 +111,6 @@ namespace Watchman.AwsResources.Services.AutoScaling
 
         public List<Dimension> GetDimensions(AutoScalingGroup resource, IList<string> dimensionNames)
         {
-
             return dimensionNames
                 .Select(x => GetDimension(resource, x))
                 .ToList();

--- a/Watchman.AwsResources/Watchman.AwsResources.csproj
+++ b/Watchman.AwsResources/Watchman.AwsResources.csproj
@@ -3,15 +3,15 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.6.5" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.8.3" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.27.2" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.14.5" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.65" />
-    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.3.5" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.16.3" />
-    <PackageReference Include="AWSSDK.RDS" Version="3.3.30" />
-    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2.20" />
+    <PackageReference Include="AWSSDK.AutoScaling" Version="3.3.8.2" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.10" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.15" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.3.75" />
+    <PackageReference Include="AWSSDK.ElasticLoadBalancing" Version="3.3.3.21" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.18" />
+    <PackageReference Include="AWSSDK.RDS" Version="3.3.37" />
+    <PackageReference Include="AWSSDK.StepFunctions" Version="3.3.2.36" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Watchman.Configuration\Watchman.Configuration.csproj" />

--- a/Watchman.Engine/Watchman.Engine.csproj
+++ b/Watchman.Engine/Watchman.Engine.csproj
@@ -3,12 +3,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.11.15" />
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.8.3" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.27.2" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.14.5" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.25" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.14" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.13" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.10" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.15" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.29" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Watchman.Tests/AutoScaling/AutoScalingAlarmTests.cs
+++ b/Watchman.Tests/AutoScaling/AutoScalingAlarmTests.cs
@@ -47,8 +47,8 @@ namespace Watchman.Tests.AutoScaling
                             && req.Dimensions.All(
                                 x => x.Name == "AutoScalingGroupName" && x.Value== autoScalingGroupName
                             )
-                            && req.EndTime == now
-                            && req.StartTime == now.AddSeconds(lagSeconds * -1)
+                            && req.EndTimeUtc == now
+                            && req.StartTimeUtc == now.AddSeconds(lagSeconds * -1)
 
                         ),
                         It.IsAny<CancellationToken>())
@@ -328,8 +328,8 @@ namespace Watchman.Tests.AutoScaling
             // assert
             ioc.GetMock<IAmazonCloudWatch>().Verify(x => x.GetMetricStatisticsAsync(
                 It.Is<GetMetricStatisticsRequest>(
-                    r => r.StartTime.Kind == DateTimeKind.Utc
-                    && r.EndTime.Kind == DateTimeKind.Utc
+                    r => r.StartTimeUtc.Kind == DateTimeKind.Utc
+                    && r.EndTimeUtc.Kind == DateTimeKind.Utc
                     ), It.IsAny<CancellationToken>())
                 );
         }


### PR DESCRIPTION
* Update to latest AWS SDKs

* And apply fixes necessary to make this work - change the `StartTime` and `EndTime` properties of a `GetMetricStatisticsRequest` to `StartTimeUtc` and `EndTimeUtc` - our code is already supplying UTC dates already.


BTW:
* the NuKeeper build automation has not submitted these package updates lately, I will check why, probably due to continual churn of new `AWSSDK.*` packages making it hard to select a stable set. [This PR](https://github.com/justeat/AwsWatchman/pull/217) failed due to the property name changes, e.g. `error CS0618: 'GetMetricStatisticsRequest.StartTime' is obsolete` [here](https://ci.appveyor.com/project/justeattech/awswatchman/builds/20031858#L124).

* Breaking change in a minor version? That's cheating at semver!