### PR TITLE
Fix SQS values name typo

### DIFF
--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -173,9 +173,9 @@ For each resource each of the default alarms will be applied. See [alarm definit
 
 Sqs will mark any queue as an error queue if it ends with "_error"
 
-- `NumberOfMessagesVisible`: 100
+- `NumberOfVisibleMessages`: 100
 - `AgeOfOldestMessage`: 600 (seconds)
-- `NumberOfMessagesVisible_Error`: 10
+- `NumberOfVisibleMessages_Error`: 10
 - `AgeOfOldestMessage_Error`: 600 (seconds)
 
 #### Options


### PR DESCRIPTION
Rename from `NumberOfMessagesVisible` to `NumberOfVisibleMessages`. `NumberOfVisibleMessages` is actually being used in the codebase.