### PR TITLE
Relaxing Alb Evaluation Periods

### DIFF
--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -503,7 +503,7 @@ namespace Watchman.Engine.Alarms
                 Name = "5xxErrorsHigh",
                 Metric = "HTTPCode_ELB_5XX_Count",
                 Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
+                EvaluationPeriods = 5,
                 Threshold = new Threshold
                 {
                     ThresholdType = ThresholdType.Absolute,
@@ -519,7 +519,7 @@ namespace Watchman.Engine.Alarms
                 Name = "Target5xxErrorsHigh",
                 Metric = "HTTPCode_Target_5XX_Count",
                 Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
+                EvaluationPeriods = 5,
                 Threshold = new Threshold
                 {
                     ThresholdType = ThresholdType.Absolute,
@@ -535,7 +535,7 @@ namespace Watchman.Engine.Alarms
                 Name = "RejectedConnectionCountHigh",
                 Metric = "RejectedConnectionCount",
                 Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
+                EvaluationPeriods = 5,
                 Threshold = new Threshold
                 {
                     ThresholdType = ThresholdType.Absolute,
@@ -551,7 +551,7 @@ namespace Watchman.Engine.Alarms
                 Name = "TargetResponseTimeHigh",
                 Metric = "TargetResponseTime",
                 Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 1,
+                EvaluationPeriods = 5,
                 ExtendedStatistic = "p99",
                 Threshold = new Threshold
                 {

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -503,7 +503,7 @@ namespace Watchman.Engine.Alarms
                 Name = "5xxErrorsHigh",
                 Metric = "HTTPCode_ELB_5XX_Count",
                 Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 5,
+                EvaluationPeriods = 2,
                 Threshold = new Threshold
                 {
                     ThresholdType = ThresholdType.Absolute,
@@ -519,7 +519,7 @@ namespace Watchman.Engine.Alarms
                 Name = "Target5xxErrorsHigh",
                 Metric = "HTTPCode_Target_5XX_Count",
                 Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 5,
+                EvaluationPeriods = 2,
                 Threshold = new Threshold
                 {
                     ThresholdType = ThresholdType.Absolute,
@@ -535,7 +535,7 @@ namespace Watchman.Engine.Alarms
                 Name = "RejectedConnectionCountHigh",
                 Metric = "RejectedConnectionCount",
                 Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 5,
+                EvaluationPeriods = 2,
                 Threshold = new Threshold
                 {
                     ThresholdType = ThresholdType.Absolute,
@@ -551,7 +551,7 @@ namespace Watchman.Engine.Alarms
                 Name = "TargetResponseTimeHigh",
                 Metric = "TargetResponseTime",
                 Period = TimeSpan.FromMinutes(1),
-                EvaluationPeriods = 5,
+                EvaluationPeriods = 2,
                 ExtendedStatistic = "p99",
                 Threshold = new Threshold
                 {

--- a/Watchman.Tests/Alb/WhenAlarmIsCreatedWithOverrides.cs
+++ b/Watchman.Tests/Alb/WhenAlarmIsCreatedWithOverrides.cs
@@ -25,7 +25,7 @@ namespace Watchman.Tests.Alb
             var alarm = _albTestSetupData.Alarms.FirstOrDefault(x => x.GetPropertyValue("AlarmName") == alarmName);
 
             Assert.That(alarm, Is.Not.Null);
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("2"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
             Assert.That(alarm.GetPropertyValue("ExtendedStatistic"), Is.Empty);
@@ -38,7 +38,7 @@ namespace Watchman.Tests.Alb
             var alarm = _albTestSetupData.Alarms.FirstOrDefault(x => x.GetPropertyValue("AlarmName") == alarmName);
 
             Assert.That(alarm, Is.Not.Null);
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("2"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
             Assert.That(alarm.GetPropertyValue("ExtendedStatistic"), Is.Empty);

--- a/Watchman.Tests/Alb/WhenAlarmIsCreatedWithOverrides.cs
+++ b/Watchman.Tests/Alb/WhenAlarmIsCreatedWithOverrides.cs
@@ -25,7 +25,7 @@ namespace Watchman.Tests.Alb
             var alarm = _albTestSetupData.Alarms.FirstOrDefault(x => x.GetPropertyValue("AlarmName") == alarmName);
 
             Assert.That(alarm, Is.Not.Null);
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("1"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
             Assert.That(alarm.GetPropertyValue("ExtendedStatistic"), Is.Empty);
@@ -38,7 +38,7 @@ namespace Watchman.Tests.Alb
             var alarm = _albTestSetupData.Alarms.FirstOrDefault(x => x.GetPropertyValue("AlarmName") == alarmName);
 
             Assert.That(alarm, Is.Not.Null);
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("1"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
             Assert.That(alarm.GetPropertyValue("ExtendedStatistic"), Is.Empty);

--- a/Watchman.Tests/Alb/WhenAlarmsAreCreatedWithDefaults.cs
+++ b/Watchman.Tests/Alb/WhenAlarmsAreCreatedWithDefaults.cs
@@ -37,7 +37,7 @@ namespace Watchman.Tests.Alb
             Assert.That(alarm.Properties["Dimensions"].First["Name"].Value<string>(), Is.EqualTo("LoadBalancer"));
             Assert.That(alarm.Properties["Dimensions"].First["Value"].Value<string>(), Is.EqualTo("loadBalancer-1"));
             Assert.That(alarm.GetPropertyValue("ComparisonOperator"), Is.EqualTo("GreaterThanOrEqualToThreshold"));
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("1"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
             Assert.That(alarm.GetPropertyValue("Period"), Is.EqualTo("60"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
@@ -58,7 +58,7 @@ namespace Watchman.Tests.Alb
             Assert.That(alarm.Properties["Dimensions"].First["Name"].Value<string>(), Is.EqualTo("LoadBalancer"));
             Assert.That(alarm.Properties["Dimensions"].First["Value"].Value<string>(), Is.EqualTo("loadBalancer-1"));
             Assert.That(alarm.GetPropertyValue("ComparisonOperator"), Is.EqualTo("GreaterThanOrEqualToThreshold"));
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("1"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
             Assert.That(alarm.GetPropertyValue("Period"), Is.EqualTo("60"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
@@ -79,7 +79,7 @@ namespace Watchman.Tests.Alb
             Assert.That(alarm.Properties["Dimensions"].First["Name"].Value<string>(), Is.EqualTo("LoadBalancer"));
             Assert.That(alarm.Properties["Dimensions"].First["Value"].Value<string>(), Is.EqualTo("loadBalancer-1"));
             Assert.That(alarm.GetPropertyValue("ComparisonOperator"), Is.EqualTo("GreaterThanOrEqualToThreshold"));
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("1"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
             Assert.That(alarm.GetPropertyValue("Period"), Is.EqualTo("60"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
@@ -100,7 +100,7 @@ namespace Watchman.Tests.Alb
             Assert.That(alarm.Properties["Dimensions"].First["Name"].Value<string>(), Is.EqualTo("LoadBalancer"));
             Assert.That(alarm.Properties["Dimensions"].First["Value"].Value<string>(), Is.EqualTo("loadBalancer-1"));
             Assert.That(alarm.GetPropertyValue("ComparisonOperator"), Is.EqualTo("GreaterThanOrEqualToThreshold"));
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("1"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
             Assert.That(alarm.GetPropertyValue("Period"), Is.EqualTo("60"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("2"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.Empty);

--- a/Watchman.Tests/Alb/WhenAlarmsAreCreatedWithDefaults.cs
+++ b/Watchman.Tests/Alb/WhenAlarmsAreCreatedWithDefaults.cs
@@ -37,7 +37,7 @@ namespace Watchman.Tests.Alb
             Assert.That(alarm.Properties["Dimensions"].First["Name"].Value<string>(), Is.EqualTo("LoadBalancer"));
             Assert.That(alarm.Properties["Dimensions"].First["Value"].Value<string>(), Is.EqualTo("loadBalancer-1"));
             Assert.That(alarm.GetPropertyValue("ComparisonOperator"), Is.EqualTo("GreaterThanOrEqualToThreshold"));
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("2"));
             Assert.That(alarm.GetPropertyValue("Period"), Is.EqualTo("60"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
@@ -58,7 +58,7 @@ namespace Watchman.Tests.Alb
             Assert.That(alarm.Properties["Dimensions"].First["Name"].Value<string>(), Is.EqualTo("LoadBalancer"));
             Assert.That(alarm.Properties["Dimensions"].First["Value"].Value<string>(), Is.EqualTo("loadBalancer-1"));
             Assert.That(alarm.GetPropertyValue("ComparisonOperator"), Is.EqualTo("GreaterThanOrEqualToThreshold"));
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("2"));
             Assert.That(alarm.GetPropertyValue("Period"), Is.EqualTo("60"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
@@ -79,7 +79,7 @@ namespace Watchman.Tests.Alb
             Assert.That(alarm.Properties["Dimensions"].First["Name"].Value<string>(), Is.EqualTo("LoadBalancer"));
             Assert.That(alarm.Properties["Dimensions"].First["Value"].Value<string>(), Is.EqualTo("loadBalancer-1"));
             Assert.That(alarm.GetPropertyValue("ComparisonOperator"), Is.EqualTo("GreaterThanOrEqualToThreshold"));
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("2"));
             Assert.That(alarm.GetPropertyValue("Period"), Is.EqualTo("60"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("10"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.EqualTo("Sum"));
@@ -100,7 +100,7 @@ namespace Watchman.Tests.Alb
             Assert.That(alarm.Properties["Dimensions"].First["Name"].Value<string>(), Is.EqualTo("LoadBalancer"));
             Assert.That(alarm.Properties["Dimensions"].First["Value"].Value<string>(), Is.EqualTo("loadBalancer-1"));
             Assert.That(alarm.GetPropertyValue("ComparisonOperator"), Is.EqualTo("GreaterThanOrEqualToThreshold"));
-            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("5"));
+            Assert.That(alarm.GetPropertyValue("EvaluationPeriods"), Is.EqualTo("2"));
             Assert.That(alarm.GetPropertyValue("Period"), Is.EqualTo("60"));
             Assert.That(alarm.GetPropertyValue("Threshold"), Is.EqualTo("2"));
             Assert.That(alarm.GetPropertyValue("Statistic"), Is.Empty);


### PR DESCRIPTION
Perhaps 1 evaluation period is a bit too strict. I have already received the response time alarm a couple times when there was no issue really. 5 evaluation periods where period is every minute seems like a more reasonable default.