### PR TITLE
Ignore tables that do not exist

### DIFF
--- a/Watchman.AwsResources/Services/DynamoDb/TableDescriptionSource.cs
+++ b/Watchman.AwsResources/Services/DynamoDb/TableDescriptionSource.cs
@@ -44,7 +44,16 @@ namespace Watchman.AwsResources.Services.DynamoDb
                 return _cachedTableDescriptions[name];
             }
 
-            var tableResponse = await _dynamoDb.DescribeTableAsync(name);
+            DescribeTableResponse tableResponse;
+
+            try
+            {
+                tableResponse = await _dynamoDb.DescribeTableAsync(name);
+            }
+            catch (ResourceNotFoundException)
+            {
+                return null;
+            }
 
             var dataItem = new AwsResource<TableDescription>(tableResponse.Table.TableName, tableResponse.Table);
             _cachedTableDescriptions.Add(tableResponse.Table.TableName, dataItem);

--- a/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/MissingResources.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/MissingResources.cs
@@ -61,5 +61,37 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.AlarmGeneratorTests
             mockery.GivenATable("table-that-exists", 1300, 600);
             mockery.ValidSnsTopic();
         }
+
+        [Test]
+        public async Task DoesNotThrowIfTableIsReturnedInListingButCannotBeDescribed()
+        {
+            var mockery = new DynamoAlarmGeneratorMockery();
+            var generator = mockery.AlarmGenerator;
+
+            mockery.GivenAListOfTables(new[] { "banana" , "apple"});
+            mockery.GivenATable("apple", 1300, 600);
+            mockery.ValidSnsTopic();
+
+            var config = new WatchmanConfiguration()
+            {
+                AlertingGroups = new List<AlertingGroup>()
+                {
+                    new AlertingGroup()
+                    {
+                        Name = "TestGroup",
+                        AlarmNameSuffix = "TestGroup",
+                        DynamoDb = new DynamoDb()
+                        {
+                            Tables = new List<Table>
+                            {
+                                new Table { Pattern = "^.*$" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            await generator.GenerateAlarmsFor(config, RunMode.GenerateAlarms);
+        }
     }
 }

--- a/Watchman.Engine/Generation/Dynamo/DynamoAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Dynamo/DynamoAlarmGenerator.cs
@@ -108,7 +108,7 @@ namespace Watchman.Engine.Generation.Dynamo
 
                 if (tableResource == null)
                 {
-                    _logger.Info($"Skipping named table {table.Name} as it does not exist");
+                    _logger.Error($"Skipping table {table.Name} as it does not exist");
                     return;
                 }
 
@@ -173,7 +173,7 @@ namespace Watchman.Engine.Generation.Dynamo
 
                 if (tableResource == null)
                 {
-                    _logger.Info($"Skipping named table {table.Name} as it does not exist");
+                    _logger.Error($"Skipping table {table.Name} as it does not exist");
                     return;
                 }
 


### PR DESCRIPTION
Either because they were specified by name and don't exist (this was already supposed to be there but probably didn't work), or because the Dynamo service returns a list of tables that don't all exist yet.