### PR TITLE
Log orphaned tables

### DIFF
--- a/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/DynamoAlarmGeneratorMockery.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/DynamoAlarmGeneratorMockery.cs
@@ -8,6 +8,7 @@ using Watchman.AwsResources;
 using Watchman.Engine.Alarms;
 using Watchman.Engine.Generation.Dynamo;
 using Watchman.Engine.Generation.Dynamo.Alarms;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 using Watchman.Engine.Sns;
 
@@ -29,8 +30,8 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.AlarmGeneratorTests
             var tableNamePopulator = new TableNamePopulator(logger, TableLoader.Object);
             var snsCreator = new SnsCreator(SnsTopicCreator.Object, SnsSubscriptionCreator.Object);
 
-            var tableAlarmCreator = new TableAlarmCreator(Cloudwatch.Object, AlarmFinder.Object, logger);
-            var indexAlarmCreator = new IndexAlarmCreator(Cloudwatch.Object, AlarmFinder.Object, logger);
+            var tableAlarmCreator = new TableAlarmCreator(Cloudwatch.Object, AlarmFinder.Object, logger, Mock.Of<ILegacyAlarmTracker>());
+            var indexAlarmCreator = new IndexAlarmCreator(Cloudwatch.Object, AlarmFinder.Object, logger, Mock.Of<ILegacyAlarmTracker>());
 
             AlarmGenerator = new DynamoAlarmGenerator(
                 logger,

--- a/Watchman.Engine.Tests/Generation/Dynamo/Alarms/IndexAlarmCreatorCapacityTests.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/Alarms/IndexAlarmCreatorCapacityTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using Watchman.Engine.Alarms;
 using Watchman.Engine.Generation.Dynamo.Alarms;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 
 namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
@@ -20,7 +21,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -38,7 +39,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -56,7 +57,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -74,7 +75,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -94,7 +95,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -114,7 +115,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object,logger.Object);
+                cloudWatch.Object, alarmFinder.Object,logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -135,7 +136,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
 
             var indexAlarmCreator = new IndexAlarmCreator(
                 cloudWatch.Object,
-                alarmFinder.Object, logger.Object);
+                alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -156,7 +157,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
 
             var indexAlarmCreator = new IndexAlarmCreator(
                 cloudWatch.Object,
-                alarmFinder.Object, logger.Object);
+                alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -176,7 +177,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -196,7 +197,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();
@@ -216,7 +217,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var indexAlarmCreator = new IndexAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
             var index = MakeIndexDescription();

--- a/Watchman.Engine.Tests/Generation/Dynamo/Alarms/TableAlarmCreatorCapacityTests.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/Alarms/TableAlarmCreatorCapacityTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using Watchman.Engine.Alarms;
 using Watchman.Engine.Generation.Dynamo.Alarms;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 
 namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
@@ -20,7 +21,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -37,7 +38,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -54,7 +55,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -71,7 +72,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -90,7 +91,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -109,7 +110,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -128,7 +129,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -147,7 +148,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -166,7 +167,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -185,7 +186,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 

--- a/Watchman.Engine.Tests/Generation/Dynamo/Alarms/TableAlarmCreatorThrottlingTests.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/Alarms/TableAlarmCreatorThrottlingTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using Watchman.Engine.Alarms;
 using Watchman.Engine.Generation.Dynamo.Alarms;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 
 namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
@@ -20,7 +21,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -37,7 +38,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -54,7 +55,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -71,7 +72,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -90,7 +91,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -109,7 +110,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -128,7 +129,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 
@@ -147,7 +148,7 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.Alarms
             var logger = new Mock<IAlarmLogger>();
 
             var tableAlarmCreator = new TableAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             var table = MakeTableDescription();
 

--- a/Watchman.Engine.Tests/Generation/Sqs/QueueLengthAlarmCreatorTests.cs
+++ b/Watchman.Engine.Tests/Generation/Sqs/QueueLengthAlarmCreatorTests.cs
@@ -3,7 +3,9 @@ using Amazon.CloudWatch;
 using Moq;
 using NUnit.Framework;
 using Watchman.Engine.Alarms;
+using Watchman.Engine.Generation.Dynamo.Alarms;
 using Watchman.Engine.Generation.Sqs;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 using Watchman.Engine.Tests.Generation.Dynamo.Alarms;
 
@@ -20,7 +22,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureLengthAlarm("testQueue", 10, "suffix", "testArn", false);
 
@@ -35,7 +37,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureLengthAlarm("testQueue", 10, "suffix", "testArn", true);
 
@@ -53,7 +55,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureLengthAlarm("testQueue", 10, "suffix", "testArn", false);
 
@@ -71,7 +73,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureLengthAlarm("testQueue", 10, "suffix", "testArn", false);
 
@@ -89,7 +91,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureLengthAlarm("testQueue", 10, "suffix", "testArn", false);
 
@@ -107,7 +109,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureLengthAlarm("testQueue", 10, "suffix", "secondTarget", false);
 

--- a/Watchman.Engine.Tests/Generation/Sqs/QueueOldestMessageAlarmCreatorTests.cs
+++ b/Watchman.Engine.Tests/Generation/Sqs/QueueOldestMessageAlarmCreatorTests.cs
@@ -3,7 +3,9 @@ using Amazon.CloudWatch;
 using Moq;
 using NUnit.Framework;
 using Watchman.Engine.Alarms;
+using Watchman.Engine.Generation.Dynamo.Alarms;
 using Watchman.Engine.Generation.Sqs;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 using Watchman.Engine.Tests.Generation.Dynamo.Alarms;
 
@@ -20,7 +22,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureOldestMessageAlarm("testQueue", 100, "suffix", "testArn", false);
 
@@ -35,7 +37,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureOldestMessageAlarm("testQueue", 100, "suffix", "testArn", true);
 
@@ -53,7 +55,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureOldestMessageAlarm("testQueue", 100, "suffix", "testArn", false);
 
@@ -71,7 +73,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureOldestMessageAlarm("testQueue", 100, "suffix", "testArn", false);
 
@@ -89,7 +91,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureOldestMessageAlarm("testQueue", 100, "suffix", "testArn", false);
 
@@ -107,7 +109,7 @@ namespace Watchman.Engine.Tests.Generation.Sqs
             var logger = new Mock<IAlarmLogger>();
 
             var queueAlarmCreator = new QueueAlarmCreator(
-                cloudWatch.Object, alarmFinder.Object, logger.Object);
+                cloudWatch.Object, alarmFinder.Object, logger.Object, Mock.Of<ILegacyAlarmTracker>());
 
             await queueAlarmCreator.EnsureOldestMessageAlarm("testQueue", 100, "suffix", "secondTarget", false);
 

--- a/Watchman.Engine/Alarms/AlarmFinder.cs
+++ b/Watchman.Engine/Alarms/AlarmFinder.cs
@@ -72,6 +72,13 @@ namespace Watchman.Engine.Alarms
             return null;
         }
 
+        public async Task<IReadOnlyCollection<MetricAlarm>> AllAlarms()
+        {
+            await Preload();
+
+            return _alarmData.Values.ToArray();
+        }
+
         public int Count => _alarmData?.Count ?? 0;
     }
 }

--- a/Watchman.Engine/Alarms/IAlarmFinder.cs
+++ b/Watchman.Engine/Alarms/IAlarmFinder.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Amazon.CloudWatch.Model;
 
 namespace Watchman.Engine.Alarms
@@ -6,6 +7,7 @@ namespace Watchman.Engine.Alarms
     public interface IAlarmFinder
     {
         Task<MetricAlarm> FindAlarmByName(string alarmName);
+        Task<IReadOnlyCollection<MetricAlarm>> AllAlarms();
         int Count { get; }
     }
 }

--- a/Watchman.Engine/Generation/AlarmLoaderAndGenerator.cs
+++ b/Watchman.Engine/Generation/AlarmLoaderAndGenerator.cs
@@ -88,12 +88,14 @@ namespace Watchman.Engine.Generation
 
         private async Task LogOrphanedAlarms()
         {
+            _logger.Info("Looking for old alarms");
+
             var orphans = await _orphanedAlarmReporter.FindOrphanedAlarms();
+            _logger.Info(
+                $"Found {orphans.Count} alarm(s) that appear to be created by AwsWatchman but are no longer managed:");
+
             if (orphans.Any())
             {
-                _logger.Info(
-                    $"Found {orphans.Count} alarm(s) that appear to be created by AwsWatchman but are no longer managed:");
-
                 foreach (var alarm in orphans)
                 {
                     _logger.Info(

--- a/Watchman.Engine/Generation/Dynamo/Alarms/IndexAlarmCreator.cs
+++ b/Watchman.Engine/Generation/Dynamo/Alarms/IndexAlarmCreator.cs
@@ -4,6 +4,7 @@ using Amazon.CloudWatch;
 using Amazon.CloudWatch.Model;
 using Amazon.DynamoDBv2.Model;
 using Watchman.Engine.Alarms;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 
 namespace Watchman.Engine.Generation.Dynamo.Alarms
@@ -13,14 +14,16 @@ namespace Watchman.Engine.Generation.Dynamo.Alarms
         private readonly IAmazonCloudWatch _cloudWatchClient;
         private readonly IAlarmFinder _alarmFinder;
         private readonly IAlarmLogger _logger;
+        private readonly ILegacyAlarmTracker _tracker;
 
         public IndexAlarmCreator(IAmazonCloudWatch cloudWatchClient,
             IAlarmFinder alarmFinder,
-            IAlarmLogger logger)
+            IAlarmLogger logger, ILegacyAlarmTracker tracker)
         {
             _cloudWatchClient = cloudWatchClient;
             _alarmFinder = alarmFinder;
             _logger = logger;
+            _tracker = tracker;
         }
 
         public int AlarmPutCount { get; private set; }
@@ -75,6 +78,8 @@ namespace Watchman.Engine.Generation.Dynamo.Alarms
             string metricName, double thresholdInUnits, int periodSeconds,
             string snsTopicArn, bool dryRun)
         {
+            _tracker.Register(alarmName);
+
             var alarmNeedsUpdate = await InspectExistingAlarm(alarmName,
                 thresholdInUnits, periodSeconds, snsTopicArn);
 

--- a/Watchman.Engine/Generation/Dynamo/Alarms/TableAlarmCreator.cs
+++ b/Watchman.Engine/Generation/Dynamo/Alarms/TableAlarmCreator.cs
@@ -3,7 +3,9 @@ using System.Threading.Tasks;
 using Amazon.CloudWatch;
 using Amazon.CloudWatch.Model;
 using Amazon.DynamoDBv2.Model;
+using Amazon.Lambda.Model;
 using Watchman.Engine.Alarms;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 
 namespace Watchman.Engine.Generation.Dynamo.Alarms
@@ -13,14 +15,17 @@ namespace Watchman.Engine.Generation.Dynamo.Alarms
         private readonly IAmazonCloudWatch _cloudWatchClient;
         private readonly IAlarmFinder _alarmFinder;
         private readonly IAlarmLogger _logger;
+        private readonly ILegacyAlarmTracker _tracker;
 
         public TableAlarmCreator(IAmazonCloudWatch cloudWatchClient,
             IAlarmFinder alarmFinder,
-            IAlarmLogger logger)
+            IAlarmLogger logger,
+            ILegacyAlarmTracker tracker)
         {
             _cloudWatchClient = cloudWatchClient;
             _alarmFinder = alarmFinder;
             _logger = logger;
+            _tracker = tracker;
         }
 
         public int AlarmPutCount { get; private set; }
@@ -74,6 +79,8 @@ namespace Watchman.Engine.Generation.Dynamo.Alarms
             double thresholdInUnits, int periodSeconds,
             string snsTopicArn, bool dryRun)
         {
+            _tracker.Register(alarmName);
+
             var alarmNeedsUpdate = await InspectExistingAlarm(alarmName,
                 thresholdInUnits, periodSeconds, snsTopicArn);
 

--- a/Watchman.Engine/LegacyTracking/ILegacyAlarmTracker.cs
+++ b/Watchman.Engine/LegacyTracking/ILegacyAlarmTracker.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Watchman.Engine.LegacyTracking
+{
+    public interface ILegacyAlarmTracker
+    {
+        void Register(string name);
+        IReadOnlyCollection<string> ActiveAlarmNames { get; }
+    }
+}

--- a/Watchman.Engine/LegacyTracking/LegacyAlarmTracker.cs
+++ b/Watchman.Engine/LegacyTracking/LegacyAlarmTracker.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Watchman.Engine.LegacyTracking
+{
+    public class LegacyAlarmTracker : ILegacyAlarmTracker
+    {
+        private readonly HashSet<string> _alarmNames = new HashSet<string>();
+
+        public IReadOnlyCollection<string> ActiveAlarmNames => _alarmNames;
+
+        public void Register(string name)
+        {
+            _alarmNames.Add(name);
+        }
+    }
+}

--- a/Watchman.Engine/LegacyTracking/OrphanedAlarmReporter.cs
+++ b/Watchman.Engine/LegacyTracking/OrphanedAlarmReporter.cs
@@ -17,13 +17,11 @@ namespace Watchman.Engine.LegacyTracking
     {
         private readonly ILegacyAlarmTracker _tracker;
         private readonly IAlarmFinder _finder;
-        private readonly IAlarmLogger _logger;
 
         public OrphanedAlarmReporter(ILegacyAlarmTracker tracker, IAlarmFinder finder, IAlarmLogger logger)
         {
             _tracker = tracker;
             _finder = finder;
-            _logger = logger;
         }
 
         public async Task<IReadOnlyList<MetricAlarm>> FindOrphanedAlarms()

--- a/Watchman.Engine/LegacyTracking/OrphanedAlarmReporter.cs
+++ b/Watchman.Engine/LegacyTracking/OrphanedAlarmReporter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudWatch.Model;
+using Watchman.Engine.Alarms;
+using Watchman.Engine.Logging;
+
+namespace Watchman.Engine.LegacyTracking
+{
+    public interface IOrphanedAlarmReporter
+    {
+        Task<IReadOnlyList<MetricAlarm>> FindOrphanedAlarms();
+    }
+
+    public class OrphanedAlarmReporter : IOrphanedAlarmReporter
+    {
+        private readonly ILegacyAlarmTracker _tracker;
+        private readonly IAlarmFinder _finder;
+        private readonly IAlarmLogger _logger;
+
+        public OrphanedAlarmReporter(ILegacyAlarmTracker tracker, IAlarmFinder finder, IAlarmLogger logger)
+        {
+            _tracker = tracker;
+            _finder = finder;
+            _logger = logger;
+        }
+
+        public async Task<IReadOnlyList<MetricAlarm>> FindOrphanedAlarms()
+        {
+            var allAlarmsBeforeRun = await _finder.AllAlarms();
+            var tracked = _tracker
+                .ActiveAlarmNames;
+
+            var relevant = allAlarmsBeforeRun
+                .Where(a => a.AlarmDescription != null)
+                // all alarms we own should have this, unless they are really really old
+
+                .Where(a =>  a.AlarmDescription.IndexOf("Watchman",
+                                 StringComparison.InvariantCultureIgnoreCase) >= 0)
+
+                // newer CloudFormation alarms have this in the name
+                // we don't care about them here
+                .Where(a =>  a.AlarmDescription.IndexOf("Alerting group",
+                                 StringComparison.InvariantCultureIgnoreCase) < 0)
+                .ToList();
+
+            var unmatched = relevant
+                .GroupJoin(tracked, alarm => alarm.AlarmName, name => name,
+                    (alarm, enumerable) => (alarm: alarm, owned: enumerable.Any()))
+                .Where(x => !x.owned)
+                .Select(x => x.alarm)
+                .ToArray();
+
+
+            return unmatched;
+        }
+    }
+}

--- a/Watchman.Tests/OrphanedAlarmReportingTests.cs
+++ b/Watchman.Tests/OrphanedAlarmReportingTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.CloudWatch;
+using Amazon.CloudWatch.Model;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Moq;
+using NUnit.Framework;
+using Watchman.Configuration;
+using Watchman.Configuration.Generic;
+using Watchman.Engine;
+using Watchman.Engine.Generation;
+using Watchman.Engine.LegacyTracking;
+using Watchman.Tests.Fakes;
+using Watchman.Tests.IoC;
+
+namespace Watchman.Tests
+{
+    [TestFixture]
+    public class OrphanedAlarmReportingTests
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task OrphanedAlarmsAreReportedCorrectly(bool configuredAlarmsAlreadyExist)
+        {
+            var cloudFormation = new FakeCloudFormation();
+            var ioc = new TestingIocBootstrapper()
+                .WithCloudFormation(cloudFormation.Instance)
+                .WithConfig(new WatchmanConfiguration()
+                {
+                    AlertingGroups = new List<AlertingGroup>()
+                    {
+                        new AlertingGroup()
+                        {
+                            Name = "TestAlertingGroup",
+                            AlarmNameSuffix = "suffix",
+                            Targets = new List<AlertTarget>()
+                            {
+                                new AlertEmail("test@example.com")
+                            },
+                            DynamoDb = new DynamoDb()
+                            {
+                                Tables = new List<Table>()
+                                {
+                                    new Table()
+                                    {
+                                        Pattern = "table-with-watchman-alarm"
+                                    }
+                                }
+                            },
+                            Sqs = new Configuration.Sqs()
+                            {
+                                Queues = new List<Queue>()
+                                {
+                                    new Queue()
+                                    {
+                                        Pattern = "queue-with-watchman-alarm"
+                                    }
+                                },
+                                Errors = new ErrorQueue()
+                                {
+                                    Monitored = true
+                                }
+                            }
+                        }
+                    }
+                });
+
+            ioc.GetMock<IAmazonDynamoDB>().HasDynamoTables(new List<TableDescription>()
+            {
+                new TableDescription()
+                {
+                    TableName = "table-with-watchman-alarm",
+                    GlobalSecondaryIndexes = new List<GlobalSecondaryIndexDescription>()
+                    {
+                        new GlobalSecondaryIndexDescription()
+                        {
+                            IndexName = "index",
+                            ProvisionedThroughput = new ProvisionedThroughputDescription()
+                        }
+                    },
+                    ProvisionedThroughput = new ProvisionedThroughputDescription()
+                }
+            });
+
+            ioc.GetMock<IAmazonCloudWatch>().HasSqsQueues(new List<string>()
+            {
+                "queue-with-watchman-alarm",
+                "queue-with-watchman-alarm_Error"
+            });
+
+            var alarmsPut = new List<string>();
+
+            ioc.GetMock<IAmazonCloudWatch>()
+                .Setup(x => x.PutMetricAlarmAsync(It.IsAny<PutMetricAlarmRequest>(), It.IsAny<CancellationToken>()))
+                .Callback((PutMetricAlarmRequest a, CancellationToken _) => alarmsPut.Add(a.AlarmName))
+                .ReturnsAsync(new PutMetricAlarmResponse());
+
+            var existingWatchmanAlarmsMatchingResources =
+                (configuredAlarmsAlreadyExist
+                    ? new[]
+                    {
+                        "table-with-watchman-alarm-ConsumedReadCapacityUnits-suffix",
+                        "table-with-watchman-alarm-ReadThrottleEvents-suffix",
+                        "table-with-watchman-alarm-index-ConsumedReadCapacityUnits-suffix",
+                        "table-with-watchman-alarm-index-ReadThrottleEvents-suffix",
+                        "table-with-watchman-alarm-WriteThrottleEvents-suffix",
+                        "table-with-watchman-alarm-index-ConsumedWriteCapacityUnits-suffix",
+                        "table-with-watchman-alarm-index-WriteThrottleEvents-suffix",
+                        "queue-with-watchman-alarm-ApproximateNumberOfMessagesVisible-suffix",
+                        "queue-with-watchman-alarm-ApproximateAgeOfOldestMessage-suffix",
+                        "queue-with-watchman-alarm_Error-ApproximateNumberOfMessagesVisible-suffix",
+                        "queue-with-watchman-alarm_Error-ApproximateAgeOfOldestMessage-suffix"
+                    }
+                    : new string[0])
+                .Select(x => new MetricAlarm()
+                {
+                    AlarmDescription = "AwsWatchman",
+                    AlarmName = x
+                })
+                .ToArray();
+
+            ioc.GetMock<IAmazonCloudWatch>()
+                .Setup(x => x.DescribeAlarmsAsync(It.IsAny<DescribeAlarmsRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DescribeAlarmsResponse()
+                {
+                    MetricAlarms = new List<MetricAlarm>()
+                    {
+                        new MetricAlarm()
+                        {
+                            AlarmDescription = "AwsWatchman",
+                            AlarmName = "orphaned-watchman-alarm"
+                        },
+                        new MetricAlarm()
+                        {
+                            AlarmDescription = "",
+                            AlarmName = "other-service-alarm"
+                        },
+                        new MetricAlarm()
+                        {
+                            AlarmDescription = "AwsWatchman. Alerting Group: test",
+                            AlarmName = "newer-cloudformation-alarm"
+                        }
+                    }.Concat(existingWatchmanAlarmsMatchingResources).ToList()
+                });
+
+            ioc.GetMock<IAmazonSimpleNotificationService>()
+                .Setup(x => x.CreateTopicAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreateTopicResponse()
+                {
+                    TopicArn = "topic-arn"
+                });
+
+            var generator = ioc.Get<AlarmLoaderAndGenerator>();
+            await generator.LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            var reporter = ioc.Get<IOrphanedAlarmReporter>();
+            var reported = await reporter.FindOrphanedAlarms();
+
+            Assert.That(alarmsPut, Is.Not.Empty);
+            Assert.That(reported.Count, Is.EqualTo(1));
+            Assert.That(reported[0].AlarmName, Is.EqualTo("orphaned-watchman-alarm"));
+        }
+    }
+}

--- a/Watchman/IoC/ApplicationRegistry.cs
+++ b/Watchman/IoC/ApplicationRegistry.cs
@@ -13,6 +13,7 @@ using Watchman.Engine.Generation.Dynamo;
 using Watchman.Engine.Generation.Dynamo.Alarms;
 using Watchman.Engine.Generation.Generic;
 using Watchman.Engine.Generation.Sqs;
+using Watchman.Engine.LegacyTracking;
 using Watchman.Engine.Logging;
 using Watchman.Engine.Sns;
 
@@ -39,7 +40,7 @@ namespace Watchman.IoC
 
             For<ITableAlarmCreator>().Use<TableAlarmCreator>();
             For<IIndexAlarmCreator>().Use<IndexAlarmCreator>();
-            For<IAlarmFinder>().Use<AlarmFinder>();
+            For<IAlarmFinder>().Use<AlarmFinder>().Singleton();
 
             For<IQueueAlarmCreator>().Use<QueueAlarmCreator>();
 
@@ -74,6 +75,9 @@ namespace Watchman.IoC
             var fileSettings = new FileSettings(parameters.ConfigFolderLocation);
 
             For<FileSettings>().Use(fileSettings);
+
+            For<ILegacyAlarmTracker>().Use<LegacyAlarmTracker>().Singleton();
+            For<IOrphanedAlarmReporter>().Use<OrphanedAlarmReporter>();
         }
 
         private static S3Location GetS3Location(StartupParameters parameters)


### PR DESCRIPTION
I'd like to start clearing out some old alarms from our environments.
The older implementations of sqs and dynamo do not clear up alarms when config is removed or the resources disappear.
This change logs those old alarms.