### PR TITLE
Fix bug where alarms are selected for multiple stacks

### DIFF
--- a/Watchman.Tests/Fakes/FakeCloudFormation.cs
+++ b/Watchman.Tests/Fakes/FakeCloudFormation.cs
@@ -87,6 +87,13 @@ namespace Watchman.Tests.Fakes
             return _submitted[name].Stack;
         }
 
+        public IReadOnlyCollection<(string name, Template template)> Stacks()
+        {
+            return _submitted
+                .Select(s => (s.Key, s.Value.Stack))
+                .ToArray();
+        }
+
         enum LastOperation
         {
             Create,


### PR DESCRIPTION
Currently alarms are suffixed in the loop but this affects how they are selected for the remaining stacks, as the alarm name is used to determine this. So they can be selected for multiple stacks.
Now we determine the destination stacks first before we start the loop to modify and deploy