### PR TITLE
Use average for ApproximateNumberOfMessagesVisible alarms

### DIFF
--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -351,7 +351,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] { "FunctionName" },
                 ComparisonOperator = ComparisonOperator.LessThanThreshold,
-                Statistic = Statistic.SampleCount,
+                Statistic = Statistic.SampleCount, //The count (number) of data points used for the statistical calculation. Is this really what we want?
                 Namespace = AwsNamespace.Lambda
             },
             new AlarmDefinition
@@ -368,7 +368,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] { "FunctionName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.SampleCount,
+                Statistic = Statistic.SampleCount, //The count (number) of data points used for the statistical calculation. Is this really what we want?
                 Namespace = AwsNamespace.Lambda
             }
         };
@@ -636,7 +636,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] { "QueueName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
+                Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Sqs
             },
             new AlarmDefinition
@@ -672,7 +672,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] { "QueueName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Sum,
+                Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Sqs
             },
             new AlarmDefinition

--- a/Watchman.Tests/Sqs/SqsAlarmTests.cs
+++ b/Watchman.Tests/Sqs/SqsAlarmTests.cs
@@ -106,7 +106,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["Threshold"].Value<int>() == 100
                         && alarm.Properties["Period"].Value<int>() == 60 * 5
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
-                        && alarm.Properties["Statistic"].Value<string>() == "Sum"
+                        && alarm.Properties["Statistic"].Value<string>() == "Average"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
                 )
             );
@@ -134,7 +134,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["Threshold"].Value<int>() == 10
                         && alarm.Properties["Period"].Value<int>() == 60 * 5
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
-                        && alarm.Properties["Statistic"].Value<string>() == "Sum"
+                        && alarm.Properties["Statistic"].Value<string>() == "Average"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
                 )
             );
@@ -356,7 +356,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["Threshold"].Value<int>() == 10
                         && alarm.Properties["Period"].Value<int>() == 60 * 5
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
-                        && alarm.Properties["Statistic"].Value<string>() == "Sum"
+                        && alarm.Properties["Statistic"].Value<string>() == "Average"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
                 )
             );


### PR DESCRIPTION
For SQS, we get messages with an absolute count on them, and sometimes we get multiple events within the same time period.

e.g. raw events
12:01.00 - 5 messages on this queue
12:02.00 - 5 messages on this queue
12:02.45 - 5 messages on this queue
12:03.00 - 5 messages on this queue

The number of messages has remained constant, but the two statistics will give us different values:

**Sum:**
12:01.00 - 5
12:02.00 - **10**
12:03.00 - 5

**Average:**
12:01.00 - 5
12:02.00 - 5
12:03.00 - 5