### PR TITLE
Adding TreatMissingData to default dynamo alarms

### DIFF
--- a/Watchman.Engine/AlarmDefinition.cs
+++ b/Watchman.Engine/AlarmDefinition.cs
@@ -38,6 +38,11 @@ namespace Watchman.Engine
         /// </summary>
         public bool AlertOnOk { get; set; } = true;
 
+        // <summary>
+        // Sets how this alarm is to handle missing data points.
+        // </summary>
+        public string TreatMissingData { get; set; } = "missing";
+
         public AlarmDefinition Copy()
         {
             return new AlarmDefinition
@@ -53,7 +58,8 @@ namespace Watchman.Engine
                 Namespace = Namespace,
                 AlertOnInsufficientData = AlertOnInsufficientData,
                 AlertOnOk = AlertOnOk,
-                ExtendedStatistic = ExtendedStatistic
+                ExtendedStatistic = ExtendedStatistic,
+                TreatMissingData = TreatMissingData
             };
         }
 

--- a/Watchman.Engine/AlarmDefinition.cs
+++ b/Watchman.Engine/AlarmDefinition.cs
@@ -41,7 +41,7 @@ namespace Watchman.Engine
         // <summary>
         // Sets how this alarm is to handle missing data points.
         // </summary>
-        public string TreatMissingData { get; set; } = "missing";
+        public string TreatMissingData { get; set; } = TreatMissingDataConstants.Missing;
 
         public AlarmDefinition Copy()
         {

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -25,7 +25,7 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb,
-                TreatMissingData = "notBreaching"
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             },
             new AlarmDefinition
             {
@@ -42,7 +42,7 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb,
-                TreatMissingData = "notBreaching"
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             }
         };
 
@@ -64,7 +64,7 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb,
-                TreatMissingData = "notBreaching"
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             },
             new AlarmDefinition
             {
@@ -81,7 +81,7 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb,
-                TreatMissingData = "notBreaching"
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             }
         };
 
@@ -104,7 +104,7 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb,
-                TreatMissingData = "notBreaching"
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             },
             new AlarmDefinition
             {
@@ -121,7 +121,7 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb,
-                TreatMissingData = "notBreaching"
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             }
         };
 
@@ -144,7 +144,7 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb,
-                TreatMissingData = "notBreaching"
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             },
             new AlarmDefinition
             {
@@ -161,7 +161,7 @@ namespace Watchman.Engine.Alarms
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
                 Namespace = AwsNamespace.DynamoDb,
-                TreatMissingData = "notBreaching"
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             }
         };
     }

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -24,7 +24,8 @@ namespace Watchman.Engine.Alarms
                 DimensionNames = new[] { "GlobalSecondaryIndexName", "TableName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
+                Namespace = AwsNamespace.DynamoDb,
+                TreatMissingData = "notBreaching"
             },
             new AlarmDefinition
             {
@@ -40,7 +41,8 @@ namespace Watchman.Engine.Alarms
                 DimensionNames = new[] { "GlobalSecondaryIndexName", "TableName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
+                Namespace = AwsNamespace.DynamoDb,
+                TreatMissingData = "notBreaching"
             }
         };
 
@@ -61,7 +63,8 @@ namespace Watchman.Engine.Alarms
                 DimensionNames = new[] { "GlobalSecondaryIndexName", "TableName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
+                Namespace = AwsNamespace.DynamoDb,
+                TreatMissingData = "notBreaching"
             },
             new AlarmDefinition
             {
@@ -77,7 +80,8 @@ namespace Watchman.Engine.Alarms
                 DimensionNames = new[] { "GlobalSecondaryIndexName", "TableName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
+                Namespace = AwsNamespace.DynamoDb,
+                TreatMissingData = "notBreaching"
             }
         };
 
@@ -99,7 +103,8 @@ namespace Watchman.Engine.Alarms
                 DimensionNames = new[] { "TableName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
+                Namespace = AwsNamespace.DynamoDb,
+                TreatMissingData = "notBreaching"
             },
             new AlarmDefinition
             {
@@ -115,7 +120,8 @@ namespace Watchman.Engine.Alarms
                 DimensionNames = new[] { "TableName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
+                Namespace = AwsNamespace.DynamoDb,
+                TreatMissingData = "notBreaching"
             }
         };
 
@@ -137,7 +143,8 @@ namespace Watchman.Engine.Alarms
                 DimensionNames = new[] { "TableName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
+                Namespace = AwsNamespace.DynamoDb,
+                TreatMissingData = "notBreaching"
             },
             new AlarmDefinition
             {
@@ -153,7 +160,8 @@ namespace Watchman.Engine.Alarms
                 DimensionNames = new[] { "TableName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
                 Statistic = Statistic.Sum,
-                Namespace = AwsNamespace.DynamoDb
+                Namespace = AwsNamespace.DynamoDb,
+                TreatMissingData = "notBreaching"
             }
         };
     }

--- a/Watchman.Engine/Generation/Generic/CloudWatchCloudFormationTemplate.cs
+++ b/Watchman.Engine/Generation/Generic/CloudWatchCloudFormationTemplate.cs
@@ -135,7 +135,8 @@ namespace Watchman.Engine.Generation.Generic
                 ComparisonOperator = definition.ComparisonOperator.Value,
                 EvaluationPeriods = definition.EvaluationPeriods,
                 Period = (int) definition.Period.TotalSeconds,
-                Threshold = definition.Threshold.Value
+                Threshold = definition.Threshold.Value,
+                TreatMissingData = definition.TreatMissingData
             };
 
             var result = JObject.FromObject(propsObject);

--- a/Watchman.Engine/TreatMissingDataConstants.cs
+++ b/Watchman.Engine/TreatMissingDataConstants.cs
@@ -1,0 +1,10 @@
+namespace Watchman.Engine
+{
+    public static class TreatMissingDataConstants
+    {
+        public const string Missing = "missing";
+        public const string NotBreaching = "notBreaching";
+        public const string Breaching = "breaching";
+        public const string Ignore = "ignore";
+    }
+}

--- a/Watchman.Tests/Dynamo/DynamoAlarmTests.cs
+++ b/Watchman.Tests/Dynamo/DynamoAlarmTests.cs
@@ -209,6 +209,7 @@ namespace Watchman.Tests.Dynamo
                     && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                     && alarm.Properties["Statistic"].Value<string>() == "Sum"
                     && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.DynamoDb
+                    && alarm.Properties["TreatMissingData"].Value<string>() == "notBreaching"
                     )
                 );
 
@@ -222,6 +223,7 @@ namespace Watchman.Tests.Dynamo
                     && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                     && alarm.Properties["Statistic"].Value<string>() == "Sum"
                     && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.DynamoDb
+                    && alarm.Properties["TreatMissingData"].Value<string>() == "notBreaching"
                 )
             );
 
@@ -237,6 +239,7 @@ namespace Watchman.Tests.Dynamo
                 Is.EqualTo("GreaterThanOrEqualToThreshold"));
             Assert.That(readThrottleAlarm.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(readThrottleAlarm.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+            Assert.That(readThrottleAlarm.Properties["TreatMissingData"].Value<string>(), Is.EqualTo("notBreaching"));
 
             var writeThrottleAlarm =
                 alarms.Single(a => a.Properties["MetricName"].Value<string>() == "WriteThrottleEvents");
@@ -251,6 +254,7 @@ namespace Watchman.Tests.Dynamo
                 Is.EqualTo("GreaterThanOrEqualToThreshold"));
             Assert.That(writeThrottleAlarm.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(writeThrottleAlarm.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
+            Assert.That(writeThrottleAlarm.Properties["TreatMissingData"].Value<string>(), Is.EqualTo("notBreaching"));
         }
 
         [Test]
@@ -336,6 +340,7 @@ namespace Watchman.Tests.Dynamo
             Assert.That(consumedRead.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(consumedRead.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
             Assert.That(consumedRead.Dimension("TableName"), Is.EqualTo("first-table"));
+            Assert.That(consumedRead.Properties["TreatMissingData"].Value<string>(), Is.EqualTo("notBreaching"));
 
             var consumedWrite = alarms.SingleOrDefault(
                 a => a.Properties["AlarmName"].ToString()
@@ -351,6 +356,7 @@ namespace Watchman.Tests.Dynamo
             Assert.That(consumedWrite.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(consumedWrite.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
             Assert.That(consumedWrite.Dimension("TableName"), Is.EqualTo("first-table"));
+            Assert.That(consumedWrite.Properties["TreatMissingData"].Value<string>(), Is.EqualTo("notBreaching"));
 
             var readThrottle = alarms.SingleOrDefault(
                 a => a.Properties["AlarmName"].ToString()
@@ -364,6 +370,7 @@ namespace Watchman.Tests.Dynamo
             Assert.That(readThrottle.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(readThrottle.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
             Assert.That(readThrottle.Dimension("TableName"), Is.EqualTo("first-table"));
+            Assert.That(readThrottle.Properties["TreatMissingData"].Value<string>(), Is.EqualTo("notBreaching"));
 
             var writeThrottle = alarms.SingleOrDefault(
                 a => a.Properties["AlarmName"].ToString()
@@ -377,6 +384,7 @@ namespace Watchman.Tests.Dynamo
             Assert.That(writeThrottle.Properties["Statistic"].Value<string>(), Is.EqualTo("Sum"));
             Assert.That(writeThrottle.Properties["Namespace"].Value<string>(), Is.EqualTo(AwsNamespace.DynamoDb));
             Assert.That(writeThrottle.Dimension("TableName"), Is.EqualTo("first-table"));
+            Assert.That(writeThrottle.Properties["TreatMissingData"].Value<string>(), Is.EqualTo("notBreaching"));
         }
 
 

--- a/Watchman.Tests/Sqs/SqsAlarmTests.cs
+++ b/Watchman.Tests/Sqs/SqsAlarmTests.cs
@@ -1,3 +1,4 @@
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -108,6 +109,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                         && alarm.Properties["Statistic"].Value<string>() == "Average"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                        && alarm.Properties["TreatMissingData"].Value<string>() != TreatMissingDataConstants.NotBreaching
                 )
             );
 
@@ -121,6 +123,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                         && alarm.Properties["Statistic"].Value<string>() == "Maximum"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                        && alarm.Properties["TreatMissingData"].Value<string>() != TreatMissingDataConstants.NotBreaching
                 )
             );
 
@@ -136,6 +139,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                         && alarm.Properties["Statistic"].Value<string>() == "Average"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                        && alarm.Properties["TreatMissingData"].Value<string>() != TreatMissingDataConstants.NotBreaching
                 )
             );
 
@@ -149,6 +153,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                         && alarm.Properties["Statistic"].Value<string>() == "Maximum"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
+                        && alarm.Properties["TreatMissingData"].Value<string>() != TreatMissingDataConstants.NotBreaching
                 )
             );
         }

--- a/Watchman.Tests/Sqs/SqsAlarmTests.cs
+++ b/Watchman.Tests/Sqs/SqsAlarmTests.cs
@@ -109,7 +109,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                         && alarm.Properties["Statistic"].Value<string>() == "Average"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
-                        && alarm.Properties["TreatMissingData"].Value<string>() != TreatMissingDataConstants.NotBreaching
+                        && alarm.Properties["TreatMissingData"].Value<string>() == TreatMissingDataConstants.Missing
                 )
             );
 
@@ -123,7 +123,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                         && alarm.Properties["Statistic"].Value<string>() == "Maximum"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
-                        && alarm.Properties["TreatMissingData"].Value<string>() != TreatMissingDataConstants.NotBreaching
+                        && alarm.Properties["TreatMissingData"].Value<string>() == TreatMissingDataConstants.Missing
                 )
             );
 
@@ -139,7 +139,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                         && alarm.Properties["Statistic"].Value<string>() == "Average"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
-                        && alarm.Properties["TreatMissingData"].Value<string>() != TreatMissingDataConstants.NotBreaching
+                        && alarm.Properties["TreatMissingData"].Value<string>() == TreatMissingDataConstants.Missing
                 )
             );
 
@@ -153,7 +153,7 @@ namespace Watchman.Tests.Sqs
                         && alarm.Properties["ComparisonOperator"].Value<string>() == "GreaterThanOrEqualToThreshold"
                         && alarm.Properties["Statistic"].Value<string>() == "Maximum"
                         && alarm.Properties["Namespace"].Value<string>() == AwsNamespace.Sqs
-                        && alarm.Properties["TreatMissingData"].Value<string>() != TreatMissingDataConstants.NotBreaching
+                        && alarm.Properties["TreatMissingData"].Value<string>() == TreatMissingDataConstants.Missing
                 )
             );
         }


### PR DESCRIPTION
Current alarms that are generated for DynamoDb tables sometimes get stuck in a firing state because there is a lack of data, and as such it is kept in the firing state. This means that alerts are not fired if the alarm triggers again.

This change adds in the AWS recommendation for this situation, rather than defaulting to "missing" which uses the last data point it treats any missing data as "not breaching" which would resolve the alarm.

> For alarms on AWS/DynamoDB metrics, we recommend to set "TreatMissingData" field to value "notBreaching", "breaching" or "ignore". Only on DynamoDB metrics, treating missing data as "missing" or "null" will overwrite to "ignore".

>In order to resolve the issue that you are facing with two alarms. Could you please change the "TreatMissingData" field to value to notBreaching so that alarm will stay in Ok state when there are no data points or missing data points for specific evaluation period. 

Supporting docs: 
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata
* https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data