### PR TITLE
Add support for absolute values on DynamoDB consumption alarms

### DIFF
--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -168,6 +168,7 @@ For each resource each of the default alarms will be applied. See [alarm definit
 
 #### Options
 - `MonitorWrites` Shorthand can be used to disable all the write alarms. Default is `true`.
+- `ThresholdIsAbsolute` If this value is true, the `Consumed` metrics above will use this value as an absolute, instead of the value calculated as a percentage of the provisioned capacity. The value is measured over a period of 60 seconds, so if you want a threshold on WCU / RCU, multiply your desired value by 60. Example: Desired alarm on RCU of 200, so threshold over 60 seconds is `12000`. Default value is `false`.
 
 ### Sqs
 

--- a/Watchman.Configuration/Generic/DynamoResourceConfig.cs
+++ b/Watchman.Configuration/Generic/DynamoResourceConfig.cs
@@ -6,7 +6,11 @@ namespace Watchman.Configuration.Generic
     {
         public static bool MonitorWritesDefault = true;
 
+        public static bool ThresholdIsAbsoluteDefault = false;
+
         public bool? MonitorWrites { get; set; }
+
+        public bool? ThresholdIsAbsolute { get; set; }
 
         public DynamoResourceConfig Merge(DynamoResourceConfig parentConfig)
         {
@@ -17,7 +21,8 @@ namespace Watchman.Configuration.Generic
 
             return new DynamoResourceConfig()
             {
-                MonitorWrites = MonitorWrites ?? parentConfig.MonitorWrites
+                MonitorWrites = MonitorWrites ?? parentConfig.MonitorWrites,
+                ThresholdIsAbsolute = ThresholdIsAbsolute ?? parentConfig.ThresholdIsAbsolute
             };
         }
     }

--- a/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
@@ -100,11 +100,16 @@ namespace Watchman.Engine.Generation.Dynamo
                 var values = mergedValuesByAlarmName.GetValueOrDefault(alarm.Name) ?? new AlarmValues();
                 var configuredThreshold = alarm.Threshold.CopyWith(value: values.Threshold);
 
+                if (service.Options?.ThresholdIsAbsolute ?? DynamoResourceConfig.ThresholdIsAbsoluteDefault)
+                {
+                    configuredThreshold.ThresholdType = ThresholdType.Absolute;
+                }
+
                 var threshold = await ThresholdCalculator.ExpandThreshold(_attributeProvider,
                     entity.Resource,
                     mergedConfig,
                     configuredThreshold);
-
+            
                 var built = alarm.CopyWith(threshold, values);
 
                 var model = new Alarm
@@ -151,6 +156,12 @@ namespace Watchman.Engine.Generation.Dynamo
                     var values = mergedValuesByAlarmName.GetValueOrDefault(alarm.Name) ?? new AlarmValues();
                     var configuredThreshold = alarm.Threshold.CopyWith(value: values.Threshold);
                     var dimensions = _gsiProvider.GetDimensions(gsi, parentTableEntity.Resource, alarm.DimensionNames);
+
+                    if (service.Options?.ThresholdIsAbsolute ?? DynamoResourceConfig.ThresholdIsAbsoluteDefault)
+                    {
+                        configuredThreshold.ThresholdType = ThresholdType.Absolute;
+                    }
+
                     var threshold = await ThresholdCalculator.ExpandThreshold(_gsiProvider,
                         gsiResource.Resource,
                         mergedConfig,

--- a/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Dynamo/DynamoResourceAlarmGenerator.cs
@@ -109,7 +109,7 @@ namespace Watchman.Engine.Generation.Dynamo
                     entity.Resource,
                     mergedConfig,
                     configuredThreshold);
-            
+
                 var built = alarm.CopyWith(threshold, values);
 
                 var model = new Alarm


### PR DESCRIPTION
In some cases you may wish to set an arbitrary value as an alarm threshold on DynamoDB RCU and WCU consumption. This is of particular value on on-demand DynamoDB tables where provisioned capacity is reported as 0 by the AWS SDK, and this project currently uses a percentage value of provisioned capacity to set alarm thresholds.

Usage:
Set an additional property `ThresholdIsAbsolute` on the `Options`:

```
"Services": {
        "DynamoDb": {
            "Resources": [
                "tablename",
                { "Name": "another-tablename" },
                { "Pattern": "^regex-tablename" },
                { 
                    "Pattern": "^some-table-" 
                    "Values": {
                        "ConsumedReadCapacityUnitsHigh": 500,
                        "ConsumedWriteCapacityUnitsHigh": {
                            "EvaluationPeriods": 5,
                            "Threshold": 400
                        },
                        "ReadThrottleEventsHigh": false // disables
                    }
                },
                { 
                    "Pattern": "^another-table-",
                    "Options": {
                        "MonitorWrites": true
                        "ThresholdIsAbsolute": true // default is false
                    }
                }
            ],
            "Values": {
                // can override defaults for the entire file here
                // these can be overridden again per resource ^^^
                "WriteThrottleEventsHigh": 100
            }
        }
    }
```