### PR TITLE
Use treat missing data propery on InvocationsLow lambda alarm

### DIFF
--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -429,8 +429,9 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] { "FunctionName" },
                 ComparisonOperator = ComparisonOperator.LessThanThreshold,
-                Statistic = Statistic.SampleCount, //The count (number) of data points used for the statistical calculation. Is this really what we want?
-                Namespace = AwsNamespace.Lambda
+                Statistic = Statistic.Sum,
+                Namespace = AwsNamespace.Lambda,
+                TreatMissingData = TreatMissingDataConstants.Breaching
             },
             new AlarmDefinition
             {


### PR DESCRIPTION
When a lambda is not invoked, there is not a metric and the alarm goes into `INSUFFICIENT_DATA` and as a result it does not fire when it should. We should alert when there is not any data as it means the lambda did not really run.

I also changed the `statistic` to `Sum` as it seems a better fit than `SampleCount`.