### PR TITLE
Set retry and timeout values, use singleton http client

### DIFF
--- a/Watchman/IoC/BoundaryRegistry.cs
+++ b/Watchman/IoC/BoundaryRegistry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using Amazon;
 using Amazon.AutoScaling;
 using Amazon.CloudFormation;
@@ -26,11 +27,13 @@ namespace Watchman.IoC
     {
         public BoundaryRegistry(StartupParameters parameters)
         {
+            For<HttpClient>().Use(_ => new HttpClient()).Singleton();
+
             SetupLocalDependencies(parameters);
             SetupAwsDependencies(parameters);
         }
 
-        private TClientConfig CreateClientConfig<TClientConfig>(RegionEndpoint region)
+        private TClientConfig CreateClientConfig<TClientConfig>(RegionEndpoint region, HttpClient client)
             where TClientConfig : ClientConfig, new()
         {
             var result = new TClientConfig()
@@ -38,7 +41,8 @@ namespace Watchman.IoC
                 RegionEndpoint = region,
                 MaxErrorRetry = 5,
                 Timeout = TimeSpan.FromSeconds(30),
-                ReadWriteTimeout = TimeSpan.FromSeconds(90)
+                ReadWriteTimeout = TimeSpan.FromSeconds(90),
+                HttpClientFactory = new SingletonHttpClientFactory(client)
             };
 
             return result;
@@ -52,55 +56,55 @@ namespace Watchman.IoC
 
             For<IAmazonDynamoDB>()
                 .Use(ctx => new AmazonDynamoDBClient(creds,
-                    CreateClientConfig<AmazonDynamoDBConfig>(region)))
+                    CreateClientConfig<AmazonDynamoDBConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonCloudWatch>()
                 .Use(ctx => new AmazonCloudWatchClient(creds,
-                    CreateClientConfig <AmazonCloudWatchConfig>(region)))
+                    CreateClientConfig <AmazonCloudWatchConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonSimpleNotificationService>()
                 .Use(ctx => new AmazonSimpleNotificationServiceClient(creds,
-                    CreateClientConfig<AmazonSimpleNotificationServiceConfig>(region)))
+                    CreateClientConfig<AmazonSimpleNotificationServiceConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonRDS>()
                 .Use(ctx => new AmazonRDSClient(creds,
-                    CreateClientConfig<AmazonRDSConfig>(region)))
+                    CreateClientConfig<AmazonRDSConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonAutoScaling>()
                 .Use(ctx => new AmazonAutoScalingClient(creds,
-                    CreateClientConfig<AmazonAutoScalingConfig>(region)))
+                    CreateClientConfig<AmazonAutoScalingConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonCloudFormation>()
                 .Use(ctx => new AmazonCloudFormationClient(creds,
-                    CreateClientConfig<AmazonCloudFormationConfig>(region)))
+                    CreateClientConfig<AmazonCloudFormationConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonLambda>()
                 .Use(ctx => new AmazonLambdaClient(creds,
-                    CreateClientConfig<AmazonLambdaConfig>(region)))
+                    CreateClientConfig<AmazonLambdaConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonEC2>()
                 .Use(ctx => new AmazonEC2Client(creds,
-                    CreateClientConfig<AmazonEC2Config>(region)))
+                    CreateClientConfig<AmazonEC2Config>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonElasticLoadBalancing>()
                 .Use(ctx => new AmazonElasticLoadBalancingClient(creds,
-                    CreateClientConfig<AmazonElasticLoadBalancingConfig>(region)))
+                    CreateClientConfig<AmazonElasticLoadBalancingConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonElasticLoadBalancingV2>()
                 .Use(ctx => new AmazonElasticLoadBalancingV2Client(creds,
-                    CreateClientConfig<AmazonElasticLoadBalancingV2Config>(region)))
+                    CreateClientConfig<AmazonElasticLoadBalancingV2Config>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonS3>()
                 .Use(ctx => new AmazonS3Client(creds,
-                    CreateClientConfig<AmazonS3Config>(region)))
+                    CreateClientConfig<AmazonS3Config>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonStepFunctions>()
                 .Use(ctx => new AmazonStepFunctionsClient(creds,
-                    CreateClientConfig<AmazonStepFunctionsConfig>(region)))
+                    CreateClientConfig<AmazonStepFunctionsConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
             For<IAmazonCloudWatch>()
                 .Use(ctx => new AmazonCloudWatchClient(creds,
-                    CreateClientConfig<AmazonCloudWatchConfig>(region)))
+                    CreateClientConfig<AmazonCloudWatchConfig>(region, ctx.GetInstance<HttpClient>())))
                 .Singleton();
         }
 

--- a/Watchman/IoC/BoundaryRegistry.cs
+++ b/Watchman/IoC/BoundaryRegistry.cs
@@ -1,3 +1,5 @@
+using System;
+using Amazon;
 using Amazon.AutoScaling;
 using Amazon.CloudFormation;
 using Amazon.CloudWatch;
@@ -7,6 +9,7 @@ using Amazon.ElasticLoadBalancing;
 using Amazon.ElasticLoadBalancingV2;
 using Amazon.Lambda;
 using Amazon.RDS;
+using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.SimpleNotificationService;
 using Amazon.StepFunctions;
@@ -27,6 +30,20 @@ namespace Watchman.IoC
             SetupAwsDependencies(parameters);
         }
 
+        private TClientConfig CreateClientConfig<TClientConfig>(RegionEndpoint region)
+            where TClientConfig : ClientConfig, new()
+        {
+            var result = new TClientConfig()
+            {
+                RegionEndpoint = region,
+                MaxErrorRetry = 5,
+                Timeout = TimeSpan.FromSeconds(30),
+                ReadWriteTimeout = TimeSpan.FromSeconds(90)
+            };
+
+            return result;
+        }
+
         private void SetupAwsDependencies(StartupParameters parameters)
         {
             var region = AwsStartup.ParseRegion(parameters.AwsRegion);
@@ -34,44 +51,56 @@ namespace Watchman.IoC
                 parameters.AwsAccessKey, parameters.AwsSecretKey, parameters.AwsProfile);
 
             For<IAmazonDynamoDB>()
-                .Use(ctx => new AmazonDynamoDBClient(creds, new AmazonDynamoDBConfig {RegionEndpoint = region}))
+                .Use(ctx => new AmazonDynamoDBClient(creds,
+                    CreateClientConfig<AmazonDynamoDBConfig>(region)))
                 .Singleton();
             For<IAmazonCloudWatch>()
-                .Use(ctx => new AmazonCloudWatchClient(creds, new AmazonCloudWatchConfig {RegionEndpoint = region}))
+                .Use(ctx => new AmazonCloudWatchClient(creds,
+                    CreateClientConfig <AmazonCloudWatchConfig>(region)))
                 .Singleton();
             For<IAmazonSimpleNotificationService>()
                 .Use(ctx => new AmazonSimpleNotificationServiceClient(creds,
-                    new AmazonSimpleNotificationServiceConfig {RegionEndpoint = region}))
+                    CreateClientConfig<AmazonSimpleNotificationServiceConfig>(region)))
                 .Singleton();
             For<IAmazonRDS>()
-                .Use(ctx => new AmazonRDSClient(creds, new AmazonRDSConfig {RegionEndpoint = region}))
+                .Use(ctx => new AmazonRDSClient(creds,
+                    CreateClientConfig<AmazonRDSConfig>(region)))
                 .Singleton();
             For<IAmazonAutoScaling>()
-                .Use(ctx => new AmazonAutoScalingClient(creds, region))
+                .Use(ctx => new AmazonAutoScalingClient(creds,
+                    CreateClientConfig<AmazonAutoScalingConfig>(region)))
                 .Singleton();
             For<IAmazonCloudFormation>()
-                .Use(ctx => new AmazonCloudFormationClient(creds, region))
+                .Use(ctx => new AmazonCloudFormationClient(creds,
+                    CreateClientConfig<AmazonCloudFormationConfig>(region)))
                 .Singleton();
             For<IAmazonLambda>()
-                .Use(ctx => new AmazonLambdaClient(creds, region))
+                .Use(ctx => new AmazonLambdaClient(creds,
+                    CreateClientConfig<AmazonLambdaConfig>(region)))
                 .Singleton();
             For<IAmazonEC2>()
-                .Use(ctx => new AmazonEC2Client(creds, region))
+                .Use(ctx => new AmazonEC2Client(creds,
+                    CreateClientConfig<AmazonEC2Config>(region)))
                 .Singleton();
             For<IAmazonElasticLoadBalancing>()
-                .Use(ctx => new AmazonElasticLoadBalancingClient(creds, region))
+                .Use(ctx => new AmazonElasticLoadBalancingClient(creds,
+                    CreateClientConfig<AmazonElasticLoadBalancingConfig>(region)))
                 .Singleton();
             For<IAmazonElasticLoadBalancingV2>()
-                .Use(ctx => new AmazonElasticLoadBalancingV2Client(creds, region))
+                .Use(ctx => new AmazonElasticLoadBalancingV2Client(creds,
+                    CreateClientConfig<AmazonElasticLoadBalancingV2Config>(region)))
                 .Singleton();
             For<IAmazonS3>()
-                .Use(ctx => new AmazonS3Client(creds, region))
+                .Use(ctx => new AmazonS3Client(creds,
+                    CreateClientConfig<AmazonS3Config>(region)))
                 .Singleton();
             For<IAmazonStepFunctions>()
-                .Use(ctx => new AmazonStepFunctionsClient(creds, region))
+                .Use(ctx => new AmazonStepFunctionsClient(creds,
+                    CreateClientConfig<AmazonStepFunctionsConfig>(region)))
                 .Singleton();
             For<IAmazonCloudWatch>()
-                .Use(ctx => new AmazonCloudWatchClient(creds, region))
+                .Use(ctx => new AmazonCloudWatchClient(creds,
+                    CreateClientConfig<AmazonCloudWatchConfig>(region)))
                 .Singleton();
         }
 

--- a/Watchman/IoC/SingletonHttpClientFactory.cs
+++ b/Watchman/IoC/SingletonHttpClientFactory.cs
@@ -1,0 +1,30 @@
+using System.Net.Http;
+using Amazon.Runtime;
+
+namespace Watchman.IoC
+{
+    class SingletonHttpClientFactory : HttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public SingletonHttpClientFactory(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public override HttpClient CreateHttpClient(IClientConfig clientConfig)
+        {
+            return _client;
+        }
+
+        public override bool UseSDKHttpClientCaching(IClientConfig clientConfig)
+        {
+            return false;
+        }
+
+        public override bool DisposeHttpClientsAfterUse(IClientConfig clientConfig)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Explicitly set retry and timeout values

We seem to see a lot of network related errors when we run this from team city agents. As there is not really a rush for the job to finish it seems better to backoff/retry a bit more (the default retries is 4 for most services)