### PR TITLE
Deploy empty config files

### DIFF
--- a/Watchman.Engine/Generation/Generic/CloudFormationAlarmCreator.cs
+++ b/Watchman.Engine/Generation/Generic/CloudFormationAlarmCreator.cs
@@ -66,11 +66,12 @@ namespace Watchman.Engine.Generation.Generic
 
             CheckForDuplicateStackNames();
 
-            foreach (var group in _alarms)
+            var groups = _alarms.Keys;
+            
+            foreach (var alertingGroup in groups)
             {
-                var alarms = group.Value;
-                var alertingGroup = group.Key;
-
+                var alarms = _alarms[alertingGroup];
+                
                 var stackName = StackName(alertingGroup);
 
                 var stacks = Enumerable.Range(0, alertingGroup.NumberOfCloudFormationStacks)

--- a/Watchman.Engine/Generation/ServiceAlarmTasks.cs
+++ b/Watchman.Engine/Generation/ServiceAlarmTasks.cs
@@ -41,6 +41,12 @@ namespace Watchman.Engine.Generation
         {
             var serviceConfig = _serviceConfigMapper(config);
 
+            // hack to make sure the alarm creator knows about all groups
+            foreach (var group in serviceConfig.AlertingGroups)
+            {
+                _creator.AddAlarms(group.GroupParameters, new List<Alarm>());
+            }
+
             if (!ServiceConfigIsPopulated(serviceConfig))
             {
                 _logger.Info($"No resources for {serviceConfig.ServiceName}. No action taken for this resource type");

--- a/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
+++ b/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
@@ -74,7 +74,6 @@ namespace Watchman.Engine.Generation
         {
             var groups = input.AlertingGroups
                 .Select(x => ServiceAlertingGroup(x, readServiceFromGroup))
-                .Where(x => x != null)
                 .ToList();
 
             return new WatchmanServiceConfiguration<TConfig>(serviceName, groups);
@@ -102,7 +101,7 @@ namespace Watchman.Engine.Generation
             var service = readServiceFromGroup(ag);
             if (service == null)
             {
-                return null;
+                return Map<T>(ag, new AwsServiceAlarms<T>());
             }
 
             return Map<T>(ag, service);

--- a/Watchman.Tests/CloudFormationDeploymentTests.cs
+++ b/Watchman.Tests/CloudFormationDeploymentTests.cs
@@ -67,7 +67,7 @@ namespace Watchman.Tests
         }
 
         [Test]
-        public async Task DoesDeployEmptyStackIfAlreadyPresent()
+        public async Task DoesDeployEmptyStackIfAlreadyPresentButResourcesNoLongerExist()
         {
             // first create a stack which has a resource
 
@@ -135,6 +135,76 @@ namespace Watchman.Tests
             Assert.That(stack.Resources.Any(x => x.Value.Type == "AWS::CloudWatch::Alarm"), Is.False);
         }
 
+        [Test]
+        public async Task DoesDeployEmptyStackIfAlreadyPresentButConfigNowEmpty()
+        {
+            // first create a stack which has a resource
+
+            var config = ConfigHelper.CreateBasicConfiguration("test", "group-suffix",
+                new AlertingGroupServices()
+                {
+                    AutoScaling = new AwsServiceAlarms<AutoScalingResourceConfig>()
+                    {
+                        Resources = new List<ResourceThresholds<AutoScalingResourceConfig>>()
+                        {
+                            new ResourceThresholds<AutoScalingResourceConfig>()
+                            {
+                                Name = "group-1"
+                            }
+                        }
+                    }
+                });
+
+            var cloudformation = new FakeCloudFormation();
+
+            var firstTestContext = new TestingIocBootstrapper()
+                .WithCloudFormation(cloudformation.Instance)
+                .WithConfig(config);
+
+            firstTestContext.GetMock<IAmazonAutoScaling>().HasAutoScalingGroups(new[]
+            {
+                new AutoScalingGroup()
+                {
+                    AutoScalingGroupName = "group-1",
+                    DesiredCapacity = 40
+                }
+            });
+
+            await firstTestContext.Get<AlarmLoaderAndGenerator>()
+                .LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            // check it got deployed
+
+            var stack = cloudformation
+                .Stack("Watchman-test");
+
+            Assert.That(stack, Is.Not.Null);
+            Assert.That(stack.Resources
+                .Values
+                .Where(r => r.Type == "AWS::CloudWatch::Alarm")
+                .Count, Is.GreaterThan(0));
+
+            // deploy empty config over the top
+
+            var emptyConfig = ConfigHelper.CreateBasicConfiguration("test", "group-suffix",
+                new AlertingGroupServices());
+
+            var secondTestContext = new TestingIocBootstrapper()
+                .WithCloudFormation(cloudformation.Instance)
+                .WithConfig(emptyConfig);
+
+
+            await secondTestContext
+                .Get<AlarmLoaderAndGenerator>()
+                .LoadAndGenerateAlarms(RunMode.GenerateAlarms);
+
+            stack = cloudformation
+                .Stack("Watchman-test");
+
+            //check we deployed an empty stack and deleted the redundant resources
+            Assert.That(stack, Is.Not.Null);
+            Assert.That(stack.Resources.Any(x => x.Value.Type == "AWS::CloudWatch::Alarm"), Is.False);
+        }
 
         [Test]
         public async Task DoesDeployMultipleStacksIfSelected()


### PR DESCRIPTION
This is a bit of a hack. Fixing it in a cleaner way requires some more thought.
The issue is that the config is all mapped into different service types, and then alarms created, but a lot of that is skipped for empty configs (in multiple places). This means that the cloudformation alarm creator is unaware of the parent group and doesn't deploy it.