### PR TITLE
Revert "Deploy empty config files"

### DIFF
--- a/Watchman.Engine/Generation/Generic/CloudFormationAlarmCreator.cs
+++ b/Watchman.Engine/Generation/Generic/CloudFormationAlarmCreator.cs
@@ -66,12 +66,11 @@ namespace Watchman.Engine.Generation.Generic
 
             CheckForDuplicateStackNames();
 
-            var groups = _alarms.Keys;
-            
-            foreach (var alertingGroup in groups)
+            foreach (var group in _alarms)
             {
-                var alarms = _alarms[alertingGroup];
-                
+                var alarms = group.Value;
+                var alertingGroup = group.Key;
+
                 var stackName = StackName(alertingGroup);
 
                 var stacks = Enumerable.Range(0, alertingGroup.NumberOfCloudFormationStacks)

--- a/Watchman.Engine/Generation/ServiceAlarmTasks.cs
+++ b/Watchman.Engine/Generation/ServiceAlarmTasks.cs
@@ -41,12 +41,6 @@ namespace Watchman.Engine.Generation
         {
             var serviceConfig = _serviceConfigMapper(config);
 
-            // hack to make sure the alarm creator knows about all groups
-            foreach (var group in serviceConfig.AlertingGroups)
-            {
-                _creator.AddAlarms(group.GroupParameters, new List<Alarm>());
-            }
-
             if (!ServiceConfigIsPopulated(serviceConfig))
             {
                 _logger.Info($"No resources for {serviceConfig.ServiceName}. No action taken for this resource type");

--- a/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
+++ b/Watchman.Engine/Generation/WatchmanServiceConfigurationMapper.cs
@@ -74,6 +74,7 @@ namespace Watchman.Engine.Generation
         {
             var groups = input.AlertingGroups
                 .Select(x => ServiceAlertingGroup(x, readServiceFromGroup))
+                .Where(x => x != null)
                 .ToList();
 
             return new WatchmanServiceConfiguration<TConfig>(serviceName, groups);
@@ -101,7 +102,7 @@ namespace Watchman.Engine.Generation
             var service = readServiceFromGroup(ag);
             if (service == null)
             {
-                return Map<T>(ag, new AwsServiceAlarms<T>());
+                return null;
             }
 
             return Map<T>(ag, service);


### PR DESCRIPTION
Reverts justeat/AwsWatchman#284

causes null reference exception 

```
Error in run : Value cannot be null.
[13:30:33]Parameter name: source
[13:30:33]   at System.Linq.Enumerable.Where[TSource](IEnumerable`1 source, Func`2 predicate)
[13:30:33]   at Watchman.Engine.Generation.ResourceNamePopulator`2.ExpandTablePatterns(AwsServiceAlarms`1 service, String alertingGroupName) in C:\BuildAgent\work\681ab0c32db9dca2\Watchman.Engine\Generation\ResourceNamePopulator.cs:line 47
[13:30:33]   at Watchman.Engine.Generation.ResourceNamePopulator`2.PopulateResourceNames(ServiceAlertingGroup`1 alertingGroup)
[13:30:33]   at Watchman.Engine.Generation.ServiceAlarmTasks`2.PopulateResourceNames(WatchmanServiceConfiguration`1 serviceConfig) in C:\BuildAgent\work\681ab0c32db9dca2\Watchman.Engine\Generation\ServiceAlarmTasks.cs:line 79
[13:30:33]   at Watchman.Engine.Generation.ServiceAlarmTasks`2.GenerateAlarmsForService(WatchmanConfiguration config, RunMode mode) in C:\BuildAgent\work\681ab0c32db9dca2\Watchman.Engine\Generation\ServiceAlarmTasks.cs:line 56
[13:30:33]   at Watchman.Engine.Generation.AlarmLoaderAndGenerator.GenerateAlarms(WatchmanConfiguration config, RunMode mode) in C:\BuildAgent\work\681ab0c32db9dca2\Watchman.Engine\Generation\AlarmLoaderAndGenerator.cs:line 119
[13:30:33]   at Watchman.Engine.Generation.AlarmLoaderAndGenerator.LoadAndGenerateAlarms(RunMode mode) in C:\BuildAgent\work\681ab0c32db9dca2\Watchman.Engine\Generation\AlarmLoaderAndGenerator.cs:line 75
```