### PR TITLE
AWS SDK logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The allowed commandline parameters are:
 * `ConfigFolder`: path to config files. Required.
 * `Verbose`: One of `true` or `false`. Give more detailed output. Optional, default is `false`.
 * `WriteCloudformationTemplatesToDirectory`. If set, alarms deployed via CloudFormation will be written to this folder instead of deployed. Note that this does not affect SQS and DynamoDb alarms which currently use a different deployment method.
+* `AwsLogging`. Enable AWS SDK logging. Default is `false`. If `true`, AWS metrics and error responses are logged to the console.
 
 AWS connection credentials will be found in the following order:
 * If `AwsAccessKey` and `AwsSecretKey` are specified, these will be used.

--- a/Watchman/Program.cs
+++ b/Watchman/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Threading.Tasks;
+using Amazon;
+using Amazon.Util;
 using Watchman.Engine.Generation;
 using Watchman.IoC;
 
@@ -22,6 +24,11 @@ namespace Watchman
         {
             try
             {
+                if (startParams.AwsLogging)
+                {
+                    SetupAwsSdkLogging();
+                }
+
                 var container = new IocBootstrapper().ConfigureContainer(startParams);
                 var alarmGenerator = container.GetInstance<AlarmLoaderAndGenerator>();
 
@@ -33,6 +40,16 @@ namespace Watchman
                 Console.Error.WriteLine($"Run failed: {ex.Message}");
                 return ExitCode.RunFailed;
             }
+        }
+
+        private static void SetupAwsSdkLogging()
+        {
+            var loggingConfig = AWSConfigs.LoggingConfig;
+            loggingConfig.LogTo = LoggingOptions.Console;
+            loggingConfig.LogMetrics = true;
+            loggingConfig.LogResponses = ResponseLoggingOption.OnError;
+            loggingConfig.LogResponsesSizeLimit = 4096;
+            loggingConfig.LogMetricsFormat = LogMetricsFormatOption.JSON;
         }
     }
 }

--- a/Watchman/StartupParameters.cs
+++ b/Watchman/StartupParameters.cs
@@ -32,5 +32,8 @@ namespace Watchman
 
         [Option("WriteCloudFormationTemplatesToDirectory", HelpText = "Output cloudformation templates to folder instead of deploying")]
         public string WriteCloudFormationTemplatesToDirectory { get; set; }
+
+        [Option("AwsLogging", HelpText = "Enable AWS SDK logging", Default = false)]
+        public bool AwsLogging { get; set; }
     }
 }


### PR DESCRIPTION
Allow this to be enabled on the command line so that error responses and metrics are logged to console.