### PR TITLE
Generate alarms for queue with `_error` suffix even when main queue is not found.

### DIFF
--- a/Watchman.AwsResources/Services/Sqs/QueueDataV2Source.cs
+++ b/Watchman.AwsResources/Services/Sqs/QueueDataV2Source.cs
@@ -1,8 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.CloudWatch;
-using Amazon.CloudWatch.Model;
 
 namespace Watchman.AwsResources.Services.Sqs
 {
@@ -28,38 +27,40 @@ namespace Watchman.AwsResources.Services.Sqs
         protected override async Task<IEnumerable<QueueDataV2>> FetchResources()
         {
             var names = await ReadActiveQueueNames();
+            var processedQueues = new List<string>();
 
-            var queues = names
-                .Where(e => !IsErrorQueue(e))
-                .Select(n =>
-                {
-                    var errorQueueName = names.FirstOrDefault(
-                        e => e.StartsWith(n) &&
-                             IsErrorQueue(e));
+            var result = new List<QueueDataV2>();
 
+            var mainQueues = names.Where(e => !IsErrorQueue(e)).ToArray();
+            var errorQueues = names.Where(e => IsErrorQueue(e)).ToArray();
 
-                    // we could have a scenario where nothing has been published/read to/from the error queue for
-                    // a few weeks so CloudWatch stops reporting it. In this case we still do want to alert on the queue
-                    // so in this case we can guess the name as it should be predictable anyway.
-                    errorQueueName = errorQueueName ?? $"{n}{ErrorQueueSuffix}";
+            foreach (var mainQueueName in mainQueues)
+            {
+                var errorQueueName = errorQueues.FirstOrDefault(e => e.StartsWith(mainQueueName, StringComparison.OrdinalIgnoreCase));
 
-                    return new QueueDataV2()
-                    {
-                        Name = n,
+                // we could have a scenario where nothing has been published/read to/from the error queue for
+                // a few weeks so CloudWatch stops reporting it. In this case we still do want to alert on the queue
+                // so in this case we can guess the name as it should be predictable anyway.
+                errorQueueName = errorQueueName ?? $"{mainQueueName}{ErrorQueueSuffix}";
 
-                        ErrorQueue = new QueueDataV2()
-                        {
-                            Name = errorQueueName
-                        }
-                    };
-                });
+                result.Add(new QueueDataV2 {Name = mainQueueName, ErrorQueue = new QueueDataV2 {Name = errorQueueName}});
 
-            return queues;
+                processedQueues.Add(mainQueueName);
+                processedQueues.Add(errorQueueName);
+            }
+
+            var unprocessedQueues = names.Except(processedQueues);
+            foreach (var queueName in unprocessedQueues)
+            {
+                result.Add(new QueueDataV2 {Name = queueName});
+            }
+
+            return result;
         }
 
-        private bool IsErrorQueue(string queueName)
+        private static bool IsErrorQueue(string queueName)
         {
-            return queueName.ToLowerInvariant().EndsWith(ErrorQueueSuffix);
+            return queueName.EndsWith(ErrorQueueSuffix, StringComparison.OrdinalIgnoreCase);
         }
 
         private const string ErrorQueueSuffix = "_error";


### PR DESCRIPTION
Currently,  error queues (with `_error` suffix) are skipped during resources loading if the main queue does not exist. This leads to the missing alarms on such queues. With this change single error queue will be treated as a general queue and alarm will be created.