### PR TITLE
Use Maximum instead of Average for number of messages in queue

### DIFF
--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -717,7 +717,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] { "QueueName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Average,
+                Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Sqs
             },
             new AlarmDefinition
@@ -753,7 +753,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] { "QueueName" },
                 ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
-                Statistic = Statistic.Average,
+                Statistic = Statistic.Maximum,
                 Namespace = AwsNamespace.Sqs
             },
             new AlarmDefinition


### PR DESCRIPTION
We recently had a "flapping" alarm caused by the old legacy system of AWS Watchman, whereby the default was "Sum" for the number of messages in queue - AWS support told us the following:

> This alarm is monitoring the "ApproximateNumberOfMessagesVisible" AWS/SQS metric. Therefore, I'll start by providing more context on this metric. There may be periods where the metric is not be reported, is delayed or there are differences with actual number of messages. This is articulated in the document [1] below:

> For standard queues, the result is approximate because of the distributed architecture of Amazon SQS. In most cases, the count should be close to the actual number of messages in the queue.

> Reviewing the datapoints between 2019-08-20 07:00 UTC to 08:00 UTC, we can see that the datapoint are not published on an exact 5 minute interval. For example, the timeframe between 07:10 and 07:15 contains two datapoints. The CloudWatch Alarm evaluates on a sliding window (minutes 1-5, 2-6, etc.). Given that the datapoints are published slightly irregularly, there are periods where there are two datapoints and, with a statistic of SUM, the CloudWatch Alarm adds the datapoints ( 310+317 = 627). If the statistic was configured as MAXIMUM, CloudWatch would have taken the larger of the two values. At avoid the alarm from flapping in the pattern you have seen, I suggest changing the alarm statistic to MAXIMUM. 

We currently take "Average", which would have averaged these two reported values, 310 + 317, but in a slow build queue, this could still lead to "flapping" boundary conditions - we should be taking the largest reported value when we receive more than 1 value