### PR TITLE
Use publish for artifacts output of build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
 fi
 
 
-dotnet build ./AwsWatchman.sln --output $artifacts --configuration $configuration || exit 1
+dotnet publish ./AwsWatchman.sln --output $artifacts --configuration $configuration || exit 1
 
 if [ $skipTests == 0 ]; then
     dotnet test ./Quartermaster.Tests/Quartermaster.Tests.csproj || exit 1


### PR DESCRIPTION
Your linux build script has lost parity with the powershell version

The output of the build script should perform a publish bringing across all the required dependencies to be launched.