### PR TITLE
Fix readme params table

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The allowed commandline parameters are:
 * `AwsRegion` The AWS region to use. Optional, default is `eu-west-1`.
 * `ConfigFolder`: path to config files. Required.
 * `Verbose`: One of `true` or `false`. Give more detailed output. Optional, default is `false`.
-* `WriteCloudformationTemplatesToDirectory`. If set, alarms deployed via CloudFormation will be written to this folder instead of deployed. Note that this does not affect SQS and DynamoDb alarms which currently use a different deployment method.
+* `WriteCloudFormationTemplatesToDirectory`. If set, alarms deployed via CloudFormation will be written to this folder instead of deployed. Note that this does not affect SQS and DynamoDb alarms which currently use a different deployment method.
 * `AwsLogging`. Enable AWS SDK logging. Default is `false`. If `true`, AWS metrics and error responses are logged to the console.
 
 AWS connection credentials will be found in the following order:


### PR DESCRIPTION
Readme suggested `WriteCloudformationTemplatesToDirectory` is the correct parameter, but it is `WriteCloudFormationTemplatesToDirectory` in code. I don't want to change the code to support both (messy) or what the readme says (breaking) so simply updating readme