### PR TITLE
Disable capacity alarms on old dynamo configs

### DIFF
--- a/LegacyConfiguration.md
+++ b/LegacyConfiguration.md
@@ -6,6 +6,7 @@
 |-------|------|-----------|------------|
 | Threshold | Decimal | Default is `0.8` (ie 80%) | The used as a percentage of the capacity to work out the alarm thresholds. Will be used as threshold of all tables listed in an AlertingGroup unless overridden for a table. |
 | MonitorThrottling | bool | Default is false | Enables monitoring on throttled reads or writes. |
+| MonitorCapacity | bool | Default is true | Enables monitoring of usage against provisioned capacity. |
 | ThrottlingThreshold| int| Optional | Set the throttling threshold - the number of throttled reads or writes in a minute that causes an alarm. |
 | Tables | Array of `Table` | ** | Array of dynamo tables to add the alerts to.<br>See below for more info on `Tables` |
 | ExcludeTablesPrefixedWith | Array of strings | | Don't add read or write alerts for any tables with these name prefixes.<br>Exclude overrides `Tables` settings.  |
@@ -24,6 +25,7 @@ Tables can either be added as strings or Table objects. If added as simple strin
 | Threshold | Decimal | Default from the `Threshold` value of containing alerting group. | Used as a fraction of the capacity to work out the alarm threshold for this table *** |
 | MonitorWrites | Boolean | Default is `true` | If `false`, no alerts are generated for writes to the table or its indexes |
 | MonitorThrottling | bool | Default from the `MonitorThrottling` value of containing alerting group. | Enables or disables monitoring on throttled reads or writes. |
+| MonitorCapacity | bool | Default from the `MonitorCapacity` value of containing alerting group. | Enables monitoring of usage against provisioned capacity. |
 | ThrottlingThreshold| int| Default from the `ThrottlingThreshold` value of containing alerting group. | Set the throttling threshold - the number of throttled reads or writes in a minute that causes an alarm. |
 
 

--- a/Watchman.Configuration.Tests/Load/ConfigFileLoaderTests.cs
+++ b/Watchman.Configuration.Tests/Load/ConfigFileLoaderTests.cs
@@ -137,6 +137,21 @@ namespace Watchman.Configuration.Tests.Load
         }
 
         [Test]
+        public void DynamoCapacityFlagRead()
+        {
+            var group = _config.AlertingGroups.FirstOrDefault(g => g.Name == "DynamoDisablingCapacity");
+
+            Assert.That(group, Is.Not.Null);
+            Assert.That(group.DynamoDb.MonitorCapacity, Is.False);
+            Assert.That(group.DynamoDb.Tables, Is.Not.Null);
+
+            var tables = group.DynamoDb.Tables;
+
+            Assert.That(tables.Single(t => t.Name ==  "test-table-no-capacity").MonitorCapacity, Is.Null);
+            Assert.That(tables.Single(t => t.Name ==  "test-table-capacity").MonitorCapacity, Is.True);
+        }
+
+        [Test]
         public void DynamoGroup2ExclusionsAreDeserialized()
         {
             var group = _config.AlertingGroups.FirstOrDefault(g => g.Name == "DynamoGroup2");

--- a/Watchman.Configuration.Tests/data/DynamoDisablingCapacity.json
+++ b/Watchman.Configuration.Tests/data/DynamoDisablingCapacity.json
@@ -1,0 +1,18 @@
+﻿{
+  "Name": "DynamoDisablingCapacity",
+  "AlarmNameSuffix": "DynamoDisablingCapacity",
+  "Targets": [
+    { "Email": "DynamoDisablingCapacity@example.com" }
+  ],
+  "DynamoDb": {
+    "MonitorCapacity": false,
+    "Threshold": 0.75,
+    "Tables": [
+      "test-table-no-capacity",
+      {
+        "Name": "test-table-capacity",
+        "MonitorCapacity": true
+      }
+    ]
+  }
+}

--- a/Watchman.Configuration/DynamoDb.cs
+++ b/Watchman.Configuration/DynamoDb.cs
@@ -14,6 +14,8 @@ namespace Watchman.Configuration
 
         public double? Threshold { get; set; }
 
+        public bool? MonitorCapacity { get; set; }
+
         public int? ThrottlingThreshold { get; set; }
 
         public bool? MonitorThrottling { get; set; }

--- a/Watchman.Configuration/Table.cs
+++ b/Watchman.Configuration/Table.cs
@@ -9,6 +9,8 @@ namespace Watchman.Configuration
 
         public bool? MonitorThrottling { get; set; }
 
+        public bool? MonitorCapacity { get; set; }
+
         public double? ThrottlingThreshold { get; set; }
 
         public static implicit operator Table(string text)
@@ -42,6 +44,7 @@ namespace Watchman.Configuration
                 && Threshold.Equals(other.Threshold)
                 && MonitorWrites.Equals(other.MonitorWrites)
                 && MonitorThrottling.Equals(other.MonitorThrottling)
+                && MonitorCapacity.Equals(other.MonitorCapacity)
                 && ThrottlingThreshold.Equals(other.ThrottlingThreshold);
         }
 

--- a/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/DisablingCapacityAlarms.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/DisablingCapacityAlarms.cs
@@ -1,0 +1,184 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Watchman.Configuration;
+using Watchman.Engine.Alarms;
+
+namespace Watchman.Engine.Tests.Generation.Dynamo.AlarmGeneratorTests
+{
+    [TestFixture]
+    public class DisablingCapacityAlarms
+    {
+        [Test]
+        public async Task SkipsTableCapacityAlarmsWhenDisabledForAlertingGroup()
+        {
+            var mockery = new DynamoAlarmGeneratorMockery();
+            var generator = mockery.AlarmGenerator;
+
+            var config = AlertingGroupData.WrapDynamo(new DynamoDb
+            {
+                MonitorThrottling = true,
+                MonitorCapacity = false,
+                Tables = new List<Table>
+                {
+                    new Table {Name = "test1"}
+                }
+            });
+
+            ConfigureTables(mockery);
+
+            await generator.GenerateAlarmsFor(config, RunMode.GenerateAlarms);
+
+            CloudwatchVerify.AlarmWasNotPutOnTable(mockery.Cloudwatch,
+                tableName: "test1",
+                metricName: "ConsumedReadCapacityUnits");
+
+            CloudwatchVerify.AlarmWasNotPutOnTable(mockery.Cloudwatch,
+                tableName: "test1",
+                metricName: "ConsumedWriteCapacityUnits");
+
+            CloudwatchVerify.AlarmWasPutOnTable(mockery.Cloudwatch, "test1", "ReadThrottleEvents");
+        }
+
+        [Test]
+        public async Task SkipsTableCapacityAlarmsWhenDisabledForTable()
+        {
+            var mockery = new DynamoAlarmGeneratorMockery();
+            var generator = mockery.AlarmGenerator;
+
+            var config = AlertingGroupData.WrapDynamo(new DynamoDb
+            {
+                MonitorThrottling = true,
+                Tables = new List<Table>
+                {
+                    new Table
+                    {
+                        Name = "test1",
+                        MonitorCapacity = false
+                    }
+                }
+            });
+
+            ConfigureTables(mockery);
+
+            await generator.GenerateAlarmsFor(config, RunMode.GenerateAlarms);
+
+            CloudwatchVerify.AlarmWasNotPutOnTable(mockery.Cloudwatch,
+                tableName: "test1",
+                metricName: "ConsumedReadCapacityUnits");
+
+            CloudwatchVerify.AlarmWasNotPutOnTable(mockery.Cloudwatch,
+                tableName: "test1",
+                metricName: "ConsumedWriteCapacityUnits");
+
+            CloudwatchVerify.AlarmWasPutOnTable(mockery.Cloudwatch, "test1", "ReadThrottleEvents");
+        }
+
+        [Test]
+        public async Task TableLevelSettingCanOverrideGroupLevel()
+        {
+            var mockery = new DynamoAlarmGeneratorMockery();
+            var generator = mockery.AlarmGenerator;
+
+            var config = AlertingGroupData.WrapDynamo(new DynamoDb
+            {
+                MonitorThrottling = true,
+                MonitorCapacity = false,
+                Tables = new List<Table>
+                {
+                    new Table
+                    {
+                        Name = "test1",
+                        MonitorCapacity = true
+                    }
+                }
+            });
+
+            ConfigureTables(mockery);
+
+            await generator.GenerateAlarmsFor(config, RunMode.GenerateAlarms);
+
+            CloudwatchVerify.AlarmWasPutOnTable(mockery.Cloudwatch, "test1", "ConsumedReadCapacityUnits");
+        }
+
+        [Test]
+        public async Task SkipsIndexCapacityAlarmsWhenDisabledForAlertingGroup()
+        {
+            var mockery = new DynamoAlarmGeneratorMockery();
+            var generator = mockery.AlarmGenerator;
+
+            var config = AlertingGroupData.WrapDynamo(new DynamoDb
+            {
+                MonitorThrottling = true,
+                MonitorCapacity = false,
+                Tables = new List<Table>
+                {
+                    new Table
+                    {
+                        Name = "test1"
+                    }
+                }
+            });
+
+            ConfigureTables(mockery);
+
+            await generator.GenerateAlarmsFor(config, RunMode.GenerateAlarms);
+
+            CloudwatchVerify.AlarmWasNotPutOnIndex(mockery.Cloudwatch,
+                tableName: "test1",
+                indexName: "test1-index",
+                metricName: "ConsumedReadCapacityUnits");
+
+            CloudwatchVerify.AlarmWasNotPutOnIndex(mockery.Cloudwatch,
+                tableName: "test1",
+                indexName: "test1-index",
+                metricName: "ConsumedWriteCapacityUnits");
+
+            CloudwatchVerify.AlarmWasPutOnIndex(mockery.Cloudwatch, "test1","test1-index","ReadThrottleEvents");
+        }
+
+        [Test]
+        public async Task SkipsIndexCapacityAlarmsWhenDisabledForTable()
+        {
+            var mockery = new DynamoAlarmGeneratorMockery();
+            var generator = mockery.AlarmGenerator;
+
+            var config = AlertingGroupData.WrapDynamo(new DynamoDb
+            {
+                MonitorThrottling = true,
+                Tables = new List<Table>
+                {
+                    new Table
+                    {
+                        Name = "test1",
+                        MonitorCapacity = false
+                    }
+                }
+            });
+
+            ConfigureTables(mockery);
+
+            await generator.GenerateAlarmsFor(config, RunMode.GenerateAlarms);
+
+            CloudwatchVerify.AlarmWasNotPutOnIndex(mockery.Cloudwatch,
+                tableName: "test1",
+                indexName: "test1-index",
+                metricName: "ConsumedReadCapacityUnits");
+
+            CloudwatchVerify.AlarmWasNotPutOnIndex(mockery.Cloudwatch,
+                tableName: "test1",
+                indexName: "test1-index",
+                metricName: "ConsumedWriteCapacityUnits");
+
+            CloudwatchVerify.AlarmWasPutOnIndex(mockery.Cloudwatch, "test1","test1-index","ReadThrottleEvents");
+        }
+
+        private static void ConfigureTables(DynamoAlarmGeneratorMockery mockery)
+        {
+            mockery.GivenAListOfTables(new[] {"test1"});
+            mockery.GivenATableWithIndex("test1", "test1-index", 10, 10);
+            mockery.ValidSnsTopic();
+        }
+    }
+}

--- a/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/DisablingCapacityAlarms.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/AlarmGeneratorTests/DisablingCapacityAlarms.cs
@@ -100,6 +100,8 @@ namespace Watchman.Engine.Tests.Generation.Dynamo.AlarmGeneratorTests
             await generator.GenerateAlarmsFor(config, RunMode.GenerateAlarms);
 
             CloudwatchVerify.AlarmWasPutOnTable(mockery.Cloudwatch, "test1", "ConsumedReadCapacityUnits");
+            
+            CloudwatchVerify.AlarmWasPutOnTable(mockery.Cloudwatch, "test1", "ConsumedWriteCapacityUnits");
         }
 
         [Test]

--- a/Watchman.Engine.Tests/Generation/Dynamo/CloudwatchVerify.cs
+++ b/Watchman.Engine.Tests/Generation/Dynamo/CloudwatchVerify.cs
@@ -28,6 +28,14 @@ namespace Watchman.Engine.Tests.Generation.Dynamo
                 && IsForTable(request, tableName));
         }
 
+        public static void AlarmWasPutOnTable(Mock<IAmazonCloudWatch> cloudwatch, string tableName, string metricName)
+        {
+            AlarmWasPutMatching(cloudwatch,
+                request =>
+                    request.MetricName == metricName
+                    && IsForTable(request, tableName) && IsNotForIndex(request));
+        }
+
         public static void AlarmWasPutOnTable(Mock<IAmazonCloudWatch> cloudwatch,
             string alarmName, string tableName, string metricName,
             int threshold, int period)
@@ -45,6 +53,16 @@ namespace Watchman.Engine.Tests.Generation.Dynamo
                 && request.Namespace == "AWS/DynamoDB"
                 && request.AlarmActions.Contains("sns-topic-arn")
                 && request.OKActions.Contains("sns-topic-arn"));
+        }
+
+        public static void AlarmWasPutOnIndex(Mock<IAmazonCloudWatch> cloudwatch,
+            string tableName, string indexName, string metricName)
+        {
+            AlarmWasPutMatching(cloudwatch,
+                request =>
+                    request.MetricName == metricName
+                    && IsForTable(request, tableName)
+                    && IsForIndex(request, indexName));
         }
 
         public static void AlarmWasPutOnIndex(Mock<IAmazonCloudWatch> cloudwatch,
@@ -98,6 +116,18 @@ namespace Watchman.Engine.Tests.Generation.Dynamo
                 && request.Namespace == "AWS/DynamoDB"), It.IsAny<CancellationToken>()), Times.Never);
         }
 
+        public static void AlarmWasNotPutOnIndex(Mock<IAmazonCloudWatch> cloudwatch,
+            string tableName, string indexName, string metricName)
+        {
+            cloudwatch.Verify(x =>
+                x.PutMetricAlarmAsync(It.Is<PutMetricAlarmRequest>(request =>
+                    request.Statistic.Value == "Sum"
+                    && IsForTable(request, tableName)
+                    && IsForIndex(request, indexName)
+                    && request.MetricName == metricName
+                    && request.Namespace == "AWS/DynamoDB"), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
         public static void AlarmWasNotPutOnMetric(Mock<IAmazonCloudWatch> cloudwatch, string metric)
         {
             cloudwatch.Verify(x =>
@@ -109,6 +139,11 @@ namespace Watchman.Engine.Tests.Generation.Dynamo
         private static bool IsForTable(PutMetricAlarmRequest r, string tableName)
         {
             return r.Dimensions.Count(x => x.Name == "TableName" && x.Value == tableName) == 1;
+        }
+
+        private static bool IsNotForIndex(PutMetricAlarmRequest r)
+        {
+            return !r.Dimensions.Any(x => x.Name == "GlobalSecondaryIndexName");
         }
 
         private static bool IsForIndex(PutMetricAlarmRequest r, string indexName)

--- a/Watchman.Engine/Generation/Dynamo/AlarmTables.cs
+++ b/Watchman.Engine/Generation/Dynamo/AlarmTables.cs
@@ -10,6 +10,7 @@ namespace Watchman.Engine.Generation.Dynamo
 
         public double Threshold { get; set; }
         public bool MonitorThrottling { get; set; }
+        public bool MonitorCapacity { get; set; }
 
         public double ThrottlingThreshold { get; set; }
 

--- a/Watchman.Engine/Generation/Dynamo/AlarmTablesHelper.cs
+++ b/Watchman.Engine/Generation/Dynamo/AlarmTablesHelper.cs
@@ -16,6 +16,7 @@ namespace Watchman.Engine.Generation.Dynamo
                 AlarmNameSuffix = alertingGroup.AlarmNameSuffix,
                 Threshold = alertingGroup.DynamoDb.Threshold ?? AwsConstants.DefaultCapacityThreshold,
                 MonitorThrottling = alertingGroup.DynamoDb.MonitorThrottling ?? true,
+                MonitorCapacity = alertingGroup.DynamoDb.MonitorCapacity ?? true,
                 Tables = filteredTables.ToList()
             };
         }
@@ -31,6 +32,7 @@ namespace Watchman.Engine.Generation.Dynamo
                 AlarmNameSuffix = alertingGroup.AlarmNameSuffix,
                 Threshold = alertingGroup.DynamoDb.Threshold ?? AwsConstants.DefaultCapacityThreshold,
                 MonitorThrottling = alertingGroup.DynamoDb.MonitorThrottling ?? true,
+                MonitorCapacity = alertingGroup.DynamoDb.MonitorCapacity ?? true,
                 Tables = filteredTables.ToList()
             };
         }

--- a/Watchman.Engine/Generation/Dynamo/DynamoAlarmGenerator.cs
+++ b/Watchman.Engine/Generation/Dynamo/DynamoAlarmGenerator.cs
@@ -115,8 +115,13 @@ namespace Watchman.Engine.Generation.Dynamo
 
                 var threshold = table.Threshold ?? alarmTables.Threshold;
 
-                await _tableAlarmCreator.EnsureReadCapacityAlarm(tableDescription, alarmTables.AlarmNameSuffix,
-                    threshold, alarmTables.SnsTopicArn, alarmTables.DryRun);
+                var monitorCapacity = table.MonitorCapacity ?? alarmTables.MonitorCapacity;
+
+                if (monitorCapacity)
+                {
+                    await _tableAlarmCreator.EnsureReadCapacityAlarm(tableDescription, alarmTables.AlarmNameSuffix,
+                        threshold, alarmTables.SnsTopicArn, alarmTables.DryRun);
+                }
 
                 var monitorThrottling = table.MonitorThrottling ?? alarmTables.MonitorThrottling;
                 var throttlingThreshold = table.ThrottlingThreshold ?? alarmTables.ThrottlingThreshold;
@@ -130,15 +135,18 @@ namespace Watchman.Engine.Generation.Dynamo
 
                 foreach (var index in tableDescription.GlobalSecondaryIndexes)
                 {
-                    await _indexAlarmCreator.EnsureReadCapacityAlarm(tableDescription, index, alarmTables.AlarmNameSuffix, threshold,
-                       alarmTables.SnsTopicArn, alarmTables.DryRun);
+                    if (monitorCapacity)
+                    {
+                        await _indexAlarmCreator.EnsureReadCapacityAlarm(tableDescription, index,
+                            alarmTables.AlarmNameSuffix, threshold,
+                            alarmTables.SnsTopicArn, alarmTables.DryRun);
+                    }
 
                     if (monitorThrottling)
                     {
                         await _indexAlarmCreator.EnsureReadThrottleAlarm(tableDescription, index, alarmTables.AlarmNameSuffix,
                             throttlingThreshold, alarmTables.SnsTopicArn, alarmTables.DryRun);
                     }
-
                 }
             }
             catch (Exception ex)
@@ -178,9 +186,13 @@ namespace Watchman.Engine.Generation.Dynamo
                 }
 
                 var threshold = table.Threshold ?? alarmTables.Threshold;
+                var monitorCapacity = table.MonitorCapacity ?? alarmTables.MonitorCapacity;
 
-                await _tableAlarmCreator.EnsureWriteCapacityAlarm(tableDescription, alarmTables.AlarmNameSuffix,
-                    threshold, alarmTables.SnsTopicArn, alarmTables.DryRun);
+                if (monitorCapacity)
+                {
+                    await _tableAlarmCreator.EnsureWriteCapacityAlarm(tableDescription, alarmTables.AlarmNameSuffix,
+                        threshold, alarmTables.SnsTopicArn, alarmTables.DryRun);
+                }
 
                 var monitorThrottling = table.MonitorThrottling ?? alarmTables.MonitorThrottling;
                 var throttlingThreshold = table.ThrottlingThreshold ?? alarmTables.ThrottlingThreshold;
@@ -194,13 +206,18 @@ namespace Watchman.Engine.Generation.Dynamo
 
                 foreach (var index in tableDescription.GlobalSecondaryIndexes)
                 {
-                    await _indexAlarmCreator.EnsureWriteCapacityAlarm(tableDescription, index, alarmTables.AlarmNameSuffix, threshold,
-                        alarmTables.SnsTopicArn, alarmTables.DryRun);
+                    if (monitorCapacity)
+                    {
+                        await _indexAlarmCreator.EnsureWriteCapacityAlarm(tableDescription, index,
+                            alarmTables.AlarmNameSuffix, threshold,
+                            alarmTables.SnsTopicArn, alarmTables.DryRun);
+                    }
 
                     if (monitorThrottling)
                     {
-                        await _indexAlarmCreator.EnsureWriteThrottleAlarm(tableDescription, index, alarmTables.AlarmNameSuffix,
-                         throttlingThreshold, alarmTables.SnsTopicArn, alarmTables.DryRun);
+                        await _indexAlarmCreator.EnsureWriteThrottleAlarm(tableDescription, index,
+                            alarmTables.AlarmNameSuffix,
+                            throttlingThreshold, alarmTables.SnsTopicArn, alarmTables.DryRun);
                     }
                 }
             }

--- a/Watchman.Engine/Generation/Dynamo/TableNamePopulator.cs
+++ b/Watchman.Engine/Generation/Dynamo/TableNamePopulator.cs
@@ -92,6 +92,7 @@ namespace Watchman.Engine.Generation.Dynamo
                 Threshold = pattern.Threshold,
                 MonitorWrites = pattern.MonitorWrites,
                 MonitorThrottling = pattern.MonitorThrottling,
+                MonitorCapacity = pattern.MonitorCapacity,
                 ThrottlingThreshold = pattern.ThrottlingThreshold
             };
         }


### PR DESCRIPTION
As required for tables without fixed provisioning 

`MonitorCapacity` can be set to `false` either for the whole alerting group (under `DynamoDb`) or individual tables/patterns

Default is `true`

This is only needed for old-style config that deploys directly (not via CloudFormation). The CloudFormation-based config already supports disabling certain alarm types.