### PR TITLE
[DNMY] Add HealthyHostCountLow Alarm

### DIFF
--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -224,6 +224,7 @@ Note that using the defaults here for all alarms is probably not that useful.
 - `SurgeQueueLengthHigh`: 200 (count)
 - `SpilloverCountHigh`: 10 (count)
 - `LatencyHigh`: 0.5 (average in seconds)
+- `HealthyHostCountLow`: 1 (count)
 - `UnHealthyHostCountHigh`: 1 (count)
 
 ### Alb

--- a/SupportedServices.md
+++ b/SupportedServices.md
@@ -233,6 +233,8 @@ Note that using the defaults here for all alarms is probably not that useful.
 - `Target5xxErrorsHigh`: 10 (count)
 - `RejectedConnectionCountHigh`: 10 (count)
 - `TargetResponseTimeHigh`: 2 (seconds) compared against `p99`
+- `HealthyHostCountLow`: 1 (count)
+- `UnHealthyHostCountHigh`: 1 (count)
 
 ### DAX
 

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -809,6 +809,40 @@ namespace Watchman.Engine.Alarms
                 Namespace = AwsNamespace.Alb,
                 TreatMissingData = TreatMissingDataConstants.NotBreaching
             },
+            new AlarmDefinition
+            {
+                Name = "UnHealthyHostCountHigh",
+                Metric = "UnHealthyHostCount",
+                Period = TimeSpan.FromMinutes(5),
+                EvaluationPeriods = 4,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = 1
+                },
+                DimensionNames = new[] { "LoadBalancerName" },
+                ComparisonOperator = ComparisonOperator.GreaterThanOrEqualToThreshold,
+                Statistic = Statistic.Average,
+                Namespace = AwsNamespace.Alb,
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
+            },
+            new AlarmDefinition
+            {
+                Name = "HealthyHostCountLow",
+                Metric = "HealthyHostCount",
+                Period = TimeSpan.FromMinutes(1),
+                EvaluationPeriods = 4,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = 1
+                },
+                DimensionNames = new[] { "LoadBalancerName" },
+                ComparisonOperator = ComparisonOperator.LessThanOrEqualToThreshold,
+                Statistic = Statistic.Minimum,
+                Namespace = AwsNamespace.Alb,
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
+            }
 
             // TODO we should add Unhealthy host count to match ELB?
         };

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -719,6 +719,23 @@ namespace Watchman.Engine.Alarms
                 Statistic = Statistic.Average,
                 Namespace = AwsNamespace.Elb,
                 TreatMissingData = TreatMissingDataConstants.NotBreaching
+            },
+            new AlarmDefinition
+            {
+                Name = "HealthyHostCountLow",
+                Metric = "HealthyHostCount",
+                Period = TimeSpan.FromMinutes(5),
+                EvaluationPeriods = 4,
+                Threshold = new Threshold
+                {
+                    ThresholdType = ThresholdType.Absolute,
+                    Value = 1
+                },
+                DimensionNames = new[] { "LoadBalancerName" },
+                ComparisonOperator = ComparisonOperator.LessThanOrEqualToThreshold,
+                Statistic = Statistic.Average,
+                Namespace = AwsNamespace.Elb,
+                TreatMissingData = TreatMissingDataConstants.NotBreaching
             }
         };
 

--- a/Watchman.Engine/Alarms/Defaults.cs
+++ b/Watchman.Engine/Alarms/Defaults.cs
@@ -724,7 +724,7 @@ namespace Watchman.Engine.Alarms
             {
                 Name = "HealthyHostCountLow",
                 Metric = "HealthyHostCount",
-                Period = TimeSpan.FromMinutes(5),
+                Period = TimeSpan.FromMinutes(1),
                 EvaluationPeriods = 4,
                 Threshold = new Threshold
                 {
@@ -733,7 +733,7 @@ namespace Watchman.Engine.Alarms
                 },
                 DimensionNames = new[] { "LoadBalancerName" },
                 ComparisonOperator = ComparisonOperator.LessThanOrEqualToThreshold,
-                Statistic = Statistic.Average,
+                Statistic = Statistic.Minimum,
                 Namespace = AwsNamespace.Elb,
                 TreatMissingData = TreatMissingDataConstants.NotBreaching
             }


### PR DESCRIPTION
In the event of a situation that may result in the ELB being low on instances.  This is different to the UnhealthyHosts option as you may have scaled too low, so all instances are healthy, there just aren't enough of them.