### PR TITLE
Fix artifact publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,5 +39,5 @@ jobs:
     - name: Publish artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: artifacts-${{ matrix.os_name }}
-        path: ./artifacts
+        name: artifacts-${{ matrix.os }}
+        path: ./artifacts/publish


### PR DESCRIPTION
- Use `os` not `os_name` which doesn't exist.
- Publish the `publish` directory, rather than everything.
